### PR TITLE
Launch default application represented by icon on Linux

### DIFF
--- a/libLumina/LuminaXDG.cpp
+++ b/libLumina/LuminaXDG.cpp
@@ -59,8 +59,8 @@ XDGDesktop LXDG::loadDesktopFile(QString filePath, bool& ok){
       if(DF.icon.isEmpty() && loc.isEmpty()){ DF.icon = val; }
       else if(loc == lang){ DF.icon = val; }
     }
-    else if( (var=="TryExec") && (DF.tryexec != "") ) { DF.tryexec = val; }
-    else if( (var=="Exec") && (DF.exec != "") ){ DF.exec = val; }   // only take the first Exec command in the file
+    else if( (var=="TryExec") && (DF.tryexec.isEmpty()) ) { DF.tryexec = val; }
+    else if( (var=="Exec") && (DF.exec.isEmpty() ) ) { DF.exec = val; }   // only take the first Exec command in the file
     else if(var=="NoDisplay" && !DF.isHidden){ DF.isHidden = (val.toLower()=="true"); }
     else if(var=="Hidden" && !DF.isHidden){ DF.isHidden = (val.toLower()=="true"); }
     else if(var=="Categories"){ DF.catList = val.split(";",QString::SkipEmptyParts); }


### PR DESCRIPTION
On Linux some desktop icons can contain multiple Exec statements, allowing the user to right-click on an icon and select alternative behaviour. Lumina previously took the last entry in the .desktop file, which usually is not the desired default. This small patch takes the first Exec entry in the .desktop file which is usually the desired behaviour.
