### PR TITLE
Added initial support for Debian/kFreeBSD

### DIFF
--- a/libLumina/LuminaOS-kFreeBSD.cpp
+++ b/libLumina/LuminaOS-kFreeBSD.cpp
@@ -1,0 +1,156 @@
+//===========================================
+//  Lumina-DE source code
+//  Copyright (c) 2014, Ken Moore
+//  Available under the 3-clause BSD license
+//  See the LICENSE file for full details
+//===========================================
+#ifdef __FreeBSD_kernel__
+#ifndef __FreeBSD__
+// The above two checks should make sure that we are on a
+// operating system using the FreeBSD kernel without actually being
+// on FreeBSD. That probably means Debian's kFreeBSD port.
+#include <QDebug>
+#include "LuminaOS.h"
+#include <unistd.h>
+#include <stdio.h> // Needed for BUFSIZ
+
+//can't read xbrightness settings - assume invalid until set
+static int screenbrightness = -1;
+
+//OS-specific prefix(s)
+QString LOS::AppPrefix(){ return "/usr/"; } //Prefix for applications
+QString LOS::SysPrefix(){ return "/usr/"; } //Prefix for system
+
+//OS-specific application shortcuts (*.desktop files)
+QString LOS::ControlPanelShortcut(){ return ""; } //system control panel
+QString LOS::AppStoreShortcut(){ return ""; } //graphical app/pkg manager
+QString LOS::QtConfigShortcut(){ return "/usr/bin/qtconfig-qt4"; } //qtconfig binary (NOT *.desktop file)
+
+// ==== ExternalDevicePaths() ====
+QStringList LOS::ExternalDevicePaths(){
+    //Returns: QStringList[<type>::::<filesystem>::::<path>]
+      //Note: <type> = [USB, HDRIVE, DVD, SDCARD, UNKNOWN]
+   QStringList devs = LUtils::getCmdOutput("mount");
+  //Now check the output
+  for(int i=0; i<devs.length(); i++){
+    if(devs[i].startsWith("/dev/")){
+      QString type = devs[i].section(" on ",0,0);
+        type.remove("/dev/");
+      //Determine the type of hardware device based on the dev node
+      if(type.startsWith("da")){ type = "USB"; }
+      else if(type.startsWith("ada")){ type = "HDRIVE"; }
+      else if(type.startsWith("mmsd")){ type = "SDCARD"; }
+      else if(type.startsWith("cd")||type.startsWith("acd")){ type="DVD"; }
+      else{ type = "UNKNOWN"; }
+      //Now put the device in the proper output format
+      devs[i] = type+"::::"+devs[i].section("(",1,1).section(",",0,0)+"::::"+devs[i].section(" on ",1,50).section("(",0,0).simplified();
+    }else{
+      //invalid device - remove it from the list
+      devs.removeAt(i);
+      i--;
+    }
+  }
+  return devs;
+}
+
+//Read screen brightness information
+int LOS::ScreenBrightness(){
+   //Returns: Screen Brightness as a percentage (0-100, with -1 for errors)
+  if(screenbrightness==-1){
+    if(QFile::exists(QDir::homePath()+"/.lumina/.currentxbrightness")){
+      int val = LUtils::readFile(QDir::homePath()+"/.lumina/.currentxbrightness").join("").simplified().toInt();
+      screenbrightness = val;
+    }
+  }
+  return screenbrightness;
+
+}
+
+//Set screen brightness
+void LOS::setScreenBrightness(int percent){
+  //ensure bounds
+  if(percent<0){percent=0;}
+  else if(percent>100){ percent=100; }
+  // float pf = percent/100.0; //convert to a decimel
+  //Run the command
+  QString cmd = "xbacklight -set %1";
+  // cmd = cmd.arg( QString::number( int(65535*pf) ) );
+  cmd = cmd.arg( QString::number( percent ) );
+  int ret = LUtils::runCmd(cmd);
+  //Save the result for later
+  if(ret!=0){ screenbrightness = -1; }
+  else{ screenbrightness = percent; }
+  LUtils::writeFile(QDir::homePath()+"/.lumina/.currentxbrightness", QStringList() << QString::number(screenbrightness), true);
+
+}
+
+//Read the current volume
+int LOS::audioVolume(){ //Returns: audio volume as a percentage (0-100, with -1 for errors)
+   return -1;    // not available on kFreeBSD yet
+}
+
+//Set the current volume
+void LOS::setAudioVolume(int percent){
+   return;
+}
+
+//Change the current volume a set amount (+ or -)
+void LOS::changeAudioVolume(int percentdiff){
+  int old_volume = audioVolume();
+  int new_volume = old_volume + percentdiff;
+  if (new_volume < 0)
+      new_volume = 0;
+  if (new_volume > 100)
+      new_volume = 100;
+  qDebug() << "Setting new volume to: " << new_volume;
+  setAudioVolume(new_volume);
+}
+
+//Check if a graphical audio mixer is installed
+bool LOS::hasMixerUtility(){
+  return QFile::exists("/usr/bin/pavucontrol");
+}
+
+//Launch the graphical audio mixer utility
+void LOS::startMixerUtility(){
+  QProcess::startDetached("/usr/bin/pavucontrol");
+}
+
+//Check for user system permission (shutdown/restart)
+bool LOS::userHasShutdownAccess(){
+  return true; //not implemented yet
+}
+
+//System Shutdown
+void LOS::systemShutdown(){ //start poweroff sequence
+  QProcess::startDetached("shutdown -h now");
+}
+
+//System Restart
+void LOS::systemRestart(){ //start reboot sequence
+  QProcess::startDetached("shutdown -r now");
+}
+
+//Battery Availability
+bool LOS::hasBattery(){
+  return false;
+}
+
+//Battery Charge Level
+int LOS::batteryCharge(){ //Returns: percent charge (0-100), anything outside that range is counted as an error
+  return -1;
+}
+
+//Battery Charging State
+bool LOS::batteryIsCharging(){
+  return false;
+}
+
+//Battery Time Remaining
+int LOS::batterySecondsLeft(){ //Returns: estimated number of seconds remaining
+  return 0; //not implemented yet for Linux
+}
+
+#endif
+#endif
+

--- a/libLumina/libLumina.pro
+++ b/libLumina/libLumina.pro
@@ -21,7 +21,8 @@ SOURCES	+= LuminaXDG.cpp \
 	LuminaOS-FreeBSD.cpp \
 	LuminaOS-DragonFly.cpp \
 	LuminaOS-OpenBSD.cpp \
-	LuminaOS-Linux.cpp
+	LuminaOS-Linux.cpp \
+        LuminaOS-kFreeBSD.cpp
 #       new OS support can be added here
 
 INCLUDEPATH += /usr/local/include

--- a/lumina-config/lumina-config.pro
+++ b/lumina-config/lumina-config.pro
@@ -22,10 +22,12 @@ FORMS    += mainUI.ui \
 
 INCLUDEPATH += ../libLumina /usr/local/include
 
-linux-* {
-  LIBS     += -L../libLumina -lLuminaUtils 
-} else {
-  LIBS     += -L../libLumina -lLuminaUtils -lQtSolutions_SingleApplication-head
+  LIBS += -L../libLumina -lLuminaUtils
+freebsd-* {
+  LIBS     += -lQtSolutions_SingleApplication-head
+}
+openbsd-g++4 {
+  LIBS     += -lQtSolutions_SingleApplication-head
 }
 
 openbsd-g++4 {

--- a/lumina-config/main.cpp
+++ b/lumina-config/main.cpp
@@ -1,9 +1,8 @@
 #include <QTranslator>
-#ifdef __linux
-   // #include <QtSolutions/qtsingleapplication.h>
-#else
+
+#ifdef __FreeBSD__
   #include <qtsingleapplication.h>
-#endif // #ifdef __linux
+#endif
 #include <QtGui/QApplication>
 #include <QDebug>
 #include <QFile>
@@ -16,7 +15,7 @@
 
 int main(int argc, char ** argv)
 {
-    #ifdef __linux
+    #ifndef __FreeBSD__
     QApplication a(argc, argv);
     #else
     QtSingleApplication a(argc, argv);

--- a/lumina-fm/lumina-fm.pro
+++ b/lumina-fm/lumina-fm.pro
@@ -24,10 +24,9 @@ FORMS    += MainUI.ui \
 
 INCLUDEPATH += ../libLumina /usr/local/include
 
-linux-* {
   LIBS     += -L../libLumina -lLuminaUtils 
-} else {
-  LIBS     += -L../libLumina -lLuminaUtils -lQtSolutions_SingleApplication-head
+freebsd-* {
+  LIBS     += -lQtSolutions_SingleApplication-head
 }
 
 openbsd-g++4 {

--- a/lumina-fm/main.cpp
+++ b/lumina-fm/main.cpp
@@ -1,9 +1,7 @@
 #include <QTranslator>
-#ifdef __linux
-   // #include <QtSolutions/qtsingleapplication.h>
-#else
+#ifdef __FreeBSD__
   #include <qtsingleapplication.h>
-#endif // #ifdef __linux
+#endif
 #include <QtGui/QApplication>
 #include <QDebug>
 #include <QFile>
@@ -22,13 +20,13 @@ int main(int argc, char ** argv)
       in << QString(argv[i]);
     }
     if(in.isEmpty()){ in << QDir::homePath(); }
-    #ifdef __linux
-    QApplication a(argc, argv);
-    #else
+    #ifdef __FreeBSD__
     QtSingleApplication a(argc, argv);
     if( a.isRunning() ){
       return !(a.sendMessage(in.join("\n")));
     }
+    #else
+    QApplication a(argc, argv);
     #endif
     a.setApplicationName("Insight File Manager");
     //Load current Locale

--- a/lumina-screenshot/lumina-screenshot.pro
+++ b/lumina-screenshot/lumina-screenshot.pro
@@ -15,10 +15,9 @@ FORMS    += MainUI.ui
 
 INCLUDEPATH += ../libLumina /usr/local/include
 
-linux-* {
   LIBS     += -L../libLumina -lLuminaUtils 
-} else {
-  LIBS     += -L../libLumina -lLuminaUtils -lQtSolutions_SingleApplication-head
+freebsd-* {
+  LIBS     += -lQtSolutions_SingleApplication-head
 }
 
 openbsd-g++4 {


### PR DESCRIPTION
This patch enables Lumina to build/run on Debian's kFreeBSD port, a branch of Debian which marries the FreeBSD kernel (and ZFS) with the GNU userland utilities and Debian's APT package manager.
The attached patch builds and runs for me on PC-BSD 10.0, Ubuntu 14.04 and Debian/kFreeBSD 7.
On the Debian/kFreeBSD platform Lumina runs and can launch programs, and manage application windows. However, audio volume, screen brightness and battery monitoring are not yet supported.
