### PR TITLE
make file-manager user-chooseable

### DIFF
--- a/lumina-config/mainUI.h
+++ b/lumina-config/mainUI.h
@@ -121,6 +121,7 @@ private slots:
 	void upmenuplugin();
 	void downmenuplugin();
 	void findmenuterminal();
+	void findmenufilemanager();
 	void checkmenuicons();
 
 	//Shortcuts Page

--- a/lumina-config/mainUI.ui
+++ b/lumina-config/mainUI.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>573</width>
-    <height>385</height>
+    <width>579</width>
+    <height>392</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -94,7 +94,7 @@
        <enum>QFrame::StyledPanel</enum>
       </property>
       <property name="currentIndex">
-       <number>5</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="page_desktop">
        <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -372,8 +372,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>157</width>
-             <height>90</height>
+             <width>166</width>
+             <height>92</height>
             </rect>
            </property>
            <attribute name="label">
@@ -454,8 +454,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>177</width>
-             <height>106</height>
+             <width>194</width>
+             <height>107</height>
             </rect>
            </property>
            <attribute name="label">
@@ -592,8 +592,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>157</width>
-             <height>90</height>
+             <width>166</width>
+             <height>92</height>
             </rect>
            </property>
            <attribute name="label">
@@ -674,8 +674,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>177</width>
-             <height>106</height>
+             <width>194</width>
+             <height>107</height>
             </rect>
            </property>
            <attribute name="label">
@@ -782,7 +782,7 @@
           </item>
          </layout>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <spacer name="horizontalSpacer_7">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -795,10 +795,10 @@
           </property>
          </spacer>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="QListWidget" name="list_menu"/>
         </item>
-        <item row="1" column="2">
+        <item row="2" column="2">
          <spacer name="horizontalSpacer_8">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -811,7 +811,7 @@
           </property>
          </spacer>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_13">
           <item>
            <widget class="QToolButton" name="tool_menu_add">
@@ -851,6 +851,30 @@
            <widget class="QToolButton" name="tool_menu_dn">
             <property name="text">
              <string notr="true">dn</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_18">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_15">
+            <property name="text">
+             <string>File Manager:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="line_menu_fm"/>
+          </item>
+          <item>
+           <widget class="QToolButton" name="tool_menu_findfm">
+            <property name="text">
+             <string>find</string>
             </property>
            </widget>
           </item>
@@ -1266,8 +1290,8 @@
                    <rect>
                     <x>0</x>
                     <y>0</y>
-                    <width>509</width>
-                    <height>71</height>
+                    <width>491</width>
+                    <height>59</height>
                    </rect>
                   </property>
                   <property name="sizePolicy">
@@ -1373,8 +1397,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>573</width>
-     <height>20</height>
+     <width>579</width>
+     <height>19</height>
     </rect>
    </property>
   </widget>

--- a/lumina-desktop/AppMenu.cpp
+++ b/lumina-desktop/AppMenu.cpp
@@ -6,6 +6,7 @@
 //===========================================
 #include "AppMenu.h"
 #include "LSession.h"
+#include "LDesktop.h"
 #include <LuminaOS.h>
 
 AppMenu::AppMenu(QWidget* parent) : QMenu(parent){
@@ -111,8 +112,9 @@ void AppMenu::launchControlPanel(){
 }
 
 void AppMenu::launchFileManager(){
-  LSession::LaunchApplication("lumina-fm");
-  //QProcess::startDetached("lumina-fm");
+  QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, QDir::homePath()+"/.lumina");
+  QString fm = QSettings("LuminaDE", "desktopsettings").value("default-filemanager","lumina-fm").toString();
+  LSession::LaunchApplication(fm);
 }
 
 void AppMenu::launchApp(QAction *act){

--- a/lumina-desktop/AppMenu.h
+++ b/lumina-desktop/AppMenu.h
@@ -19,6 +19,7 @@
 #include <QDateTime>
 #include <QHash>
 #include <QAction>
+#include <QSettings>
 //#include <QProcess>
 
 // libLumina includes
@@ -29,18 +30,19 @@ class AppMenu : public QMenu{
 public:
 	AppMenu(QWidget *parent = 0);
 	~AppMenu();
-	
+
 	QHash<QString, QList<XDGDesktop> > *currentAppHash();
 	QDateTime lastHashUpdate;
 
 private:
+	QSettings *settings;
 	QFileSystemWatcher *watcher;
 	QString appstorelink, controlpanellink;
 	QList<QMenu> MLIST;
 	QHash<QString, QList<XDGDesktop> > APPS;
-	
+
 	void updateAppList(); //completely update the menu lists
-	
+
 private slots:
 	void start(); //This is called in a new thread after initialization
 	void watcherUpdate();

--- a/lumina-desktop/LDesktop.cpp
+++ b/lumina-desktop/LDesktop.cpp
@@ -91,7 +91,8 @@ void LDesktop::SystemTerminal(){
 }
 
 void LDesktop::SystemFileManager(){
-  LSession::LaunchApplication("lumina-fm");
+  QString fm = settings->value("default-filemanager","lumina-fm").toString();
+  LSession::LaunchApplication(fm);
 }
 
 void LDesktop::SystemApplication(QAction* act){

--- a/lumina-open/main.cpp
+++ b/lumina-open/main.cpp
@@ -23,6 +23,7 @@
 #include <QColor>
 #include <QFont>
 #include <QTextCodec>
+#include <QSettings>
 
 #include "LFileDialog.h"
 
@@ -73,11 +74,12 @@ void showOSD(int argc, char **argv, QString message){
 }
 
 QString cmdFromUser(int argc, char **argv, QString inFile, QString extension, QString& path, bool showDLG=false){
+    QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, QDir::homePath()+"/.lumina");
     //First check to see if there is a default for this extension
     QString defApp = LFileDialog::getDefaultApp(extension);
     if(extension=="directory" && defApp.isEmpty() && !showDLG){
       //Just use the Lumina File Manager
-      return "lumina-fm";
+      return QSettings("LuminaDE", "desktopsettings").value("default-filemanager","lumina-fm").toString();
     }else if( !defApp.isEmpty() && !showDLG ){
       bool ok = false;
       XDGDesktop DF = LXDG::loadDesktopFile(defApp, ok);
@@ -137,6 +139,7 @@ QString cmdFromUser(int argc, char **argv, QString inFile, QString extension, QS
 void getCMD(int argc, char ** argv, QString& binary, QString& args, QString& path){
   //Get the input file
   QString inFile;
+  QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, QDir::homePath()+"/.lumina");
   bool showDLG = false; //flag to bypass any default application setting
   if(argc > 1){
     for(int i=1; i<argc; i++){
@@ -197,7 +200,7 @@ void getCMD(int argc, char ** argv, QString& binary, QString& args, QString& pat
   QString cmd;
   bool useInputFile = false;
   if(extension=="directory" && !showDLG){
-    cmd = "lumina-fm";
+    cmd = QSettings("LuminaDE", "desktopsettings").value("default-filemanager","lumina-fm").toString();
     useInputFile=true;
   }else if(extension=="desktop" && !showDLG){
     bool ok = false;


### PR DESCRIPTION
The user-widget and lumina-open are pretty powerful. But file managers are a matter of choice, not everyone might want to use lumina-fm/insight. This add the ability for the user-widget, app-menu, lumina-open and lumina-config to change the default file manager, respectively make use of the selected one.
