### PR TITLE
include fixes

### DIFF
--- a/lumina-desktop/LSession.h
+++ b/lumina-desktop/LSession.h
@@ -21,6 +21,7 @@
 #include <Phonon/MediaObject>
 #include <Phonon/AudioOutput>
 #include <QThread>
+#include <QUrl>
 
 #include "Globals.h"
 #include "AppMenu.h"

--- a/lumina-fm/MainUI.h
+++ b/lumina-fm/MainUI.h
@@ -37,6 +37,7 @@
 #include <QResizeEvent>
 #include <QDesktopWidget>
 #include <QThread>
+#include <QUrl>
 
 //Phonon widgets
 #include <Phonon/BackendCapabilities>


### PR DESCRIPTION
Add #include <QUrl> to prevent "invalid use of incomplete type 'class QUrl'" and "forward declaration of 'class QUrl'" compiler errors.
