### PR TITLE
lthemeengine: check if dirs ends with "/"

### DIFF
--- a/src-qt5/core/lumina-theme-engine/src/lthemeengine/lthemeengine.cpp
+++ b/src-qt5/core/lumina-theme-engine/src/lthemeengine/lthemeengine.cpp
@@ -61,7 +61,10 @@ QStringList lthemeengine::sharedStyleSheetPath(){
   dirs << QString(getenv("XDG_CONFIG_HOME"));
   dirs << QString(getenv("XDG_CONFIG_DIRS")).split(":");
   dirs << QString(getenv("XDG_DATA_DIRS")).split(":");
-  for(int i=0; i<dirs.length(); i++){ dirs[i].append("/lthemeengine/qss/"); }
+  for(int i=0; i<dirs.length(); i++){
+      if (!dirs[i].endsWith("/")){ dirs[i].append("/"); }
+      dirs[i].append("lthemeengine/qss/");
+  }
   if(dirs.isEmpty()){ dirs << LTHEMEENGINE_DATADIR"/lthemeengine/qss/"; } //no XDG settings - use the hardcoded path
   return dirs;
  }
@@ -75,7 +78,10 @@ QStringList lthemeengine::sharedDesktopStyleSheetPath(){
   dirs << QString(getenv("XDG_CONFIG_HOME"));
   dirs << QString(getenv("XDG_CONFIG_DIRS")).split(":");
   dirs << QString(getenv("XDG_DATA_DIRS")).split(":");
-  for(int i=0; i<dirs.length(); i++){ dirs[i].append("/lthemeengine/desktop_qss/"); }
+  for(int i=0; i<dirs.length(); i++){
+      if (!dirs[i].endsWith("/")){ dirs[i].append("/"); }
+      dirs[i].append("lthemeengine/desktop_qss/");
+  }
   if(dirs.isEmpty()){ dirs << LTHEMEENGINE_DATADIR"/lthemeengine/desktop_qss/"; } //no XDG settings - use the hardcoded path
   return dirs;
  }
@@ -89,7 +95,10 @@ QStringList lthemeengine::sharedColorSchemePath(){
   dirs << QString(getenv("XDG_CONFIG_HOME"));
   dirs << QString(getenv("XDG_CONFIG_DIRS")).split(":");
   dirs << QString(getenv("XDG_DATA_DIRS")).split(":");
-  for(int i=0; i<dirs.length(); i++){ dirs[i].append("/lthemeengine/colors/"); }
+  for(int i=0; i<dirs.length(); i++){
+      if (!dirs[i].endsWith("/")){ dirs[i].append("/"); }
+      dirs[i].append("lthemeengine/colors/");
+  }
   if(dirs.isEmpty()){ dirs << LTHEMEENGINE_DATADIR"/lthemeengine/colors/"; } //no XDG settings - use the hardcoded path
   qDebug() << "Got Color Dirs:" << dirs;
   return dirs;


### PR DESCRIPTION
Noticed that my saved qss themes was not loaded in the theme settings. This is due to an issue with "//" on some of the style paths that breaks the "enabled.contains" check when loading the qss files.