### PR TITLE
lumina-desktop: add basic clipboard support

### DIFF
--- a/src-qt5/core/lumina-desktop/LSession.h
+++ b/src-qt5/core/lumina-desktop/LSession.h
@@ -21,6 +21,7 @@
 #include <QMediaPlayer>
 #include <QThread>
 #include <QUrl>
+#include <QClipboard>
 
 #include "Globals.h"
 #include "AppMenu.h"
@@ -141,6 +142,8 @@ private:
 
 	int VersionStringToNumber(QString version);
 
+    bool ignoreClipboard; // flag for (handle/store)Clipboard
+
 public slots:
 	void StartLogout();
 	void StartShutdown(bool skipupdates = false);
@@ -169,6 +172,10 @@ private slots:
 
 
 	void SessionEnding();
+
+    // Clipboard
+    void handleClipboard(QClipboard::Mode mode);
+    void storeClipboard(QString text, QClipboard::Mode mode);
 
 signals:
 	//System Tray Signals


### PR DESCRIPTION
I need clipboard support. I first tough about just making a systray app, but I don't need a "klipper" clone, just basic copy/paste. Then I thought about adding it as a panel plugin, but since you can run several instances of the plugins that will complicate things. So I just added it in LSession. Is this is the best method? Probably not, but it provides basic clipboard support (what most users just need).