### PR TITLE
Support xdg-open

### DIFF
--- a/src-qt5/core/lumina-open/main.cpp
+++ b/src-qt5/core/lumina-open/main.cpp
@@ -43,7 +43,7 @@ void printUsageInfo(){
   qDebug() << " \"-brightness[up/down]\" Flag to increase/decrease screen brightness by 5%";
   qDebug() << " \"-autostart-apps\" Flag to launch all the various apps which are registered with XDG autostart specification";
   qDebug() << "\"-terminal\" Flag to open the terminal currently set as the user's default";
-  exit(1);
+  exit(0);
 }
 
 void ShowErrorDialog(int argc, char **argv, QString message){

--- a/src-qt5/core/lumina-session/main.cpp
+++ b/src-qt5/core/lumina-session/main.cpp
@@ -83,6 +83,7 @@ int main(int argc, char ** argv)
     LXDG::setEnvironmentVars();
     setenv("DESKTOP_SESSION","Lumina",1);
     setenv("XDG_CURRENT_DESKTOP","Lumina",1);
+    setenv("DE", "lumina",1); // xdg-open support
     unsetenv("QT_QPA_PLATFORMTHEME"); //causes issues with Lumina themes - not many people have this by default...
     //Startup the session
     QApplication a(argc, argv);


### PR DESCRIPTION
Lumina needs support for xdg-open. These patches depend on https://github.com/freedesktop/xdg-utils/pull/3 to work.