### PR TITLE
lumina-fm: fix #549 . Don't run currentDirectoryChanged on empty dir.

### DIFF
--- a/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.cpp
+++ b/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.cpp
@@ -663,6 +663,7 @@ void DirWidget::UpdateContextMenu(){
 
 void DirWidget::currentDirectoryChanged(QString cur, bool widgetonly){
   //qDebug() << "Got current directory changed:" << cur << widgetonly;
+  if (cur.isEmpty()) { return; }
   QFileInfo info(cur);
   canmodify = info.isWritable();
   if(widgetonly){ ui->label_status->setText(currentBrowser()->status()); }


### PR DESCRIPTION
Fix for issue #549.