### PR TITLE
Add menu to create new directory in lumina-fm

### DIFF
--- a/src-qt5/desktop-utils/lumina-fm/MainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-fm/MainUI.cpp
@@ -424,15 +424,15 @@ void MainUI::RebuildDeviceMenu(){
     }
     QAction *act = new QAction(label,this);
         act->setWhatsThis(path); //full path to mountpoint
-	act->setToolTip( QString(tr("Filesystem: %1")).arg( devs[i].section("::::",1,1) ) );
-	//Now set the appropriate icon
-	QString type = devs[i].section("::::",0,0);
-	if(type=="USB"){ type = "drive-removable-media-usb"; }
-	else if(type=="HDRIVE" || type=="LVM"){ type = "drive-harddisk"; }
-	else if(type=="SDCARD"){ type = "media-flash-sd-mmc"; }
-	else if(type=="DVD"){ type = "media-optical"; }
-	else{ type = "drive-removable-media"; }
-	act->setIcon( LXDG::findIcon(type, "") );
+    act->setToolTip( QString(tr("Filesystem: %1")).arg( devs[i].section("::::",1,1) ) );
+    //Now set the appropriate icon
+    QString type = devs[i].section("::::",0,0);
+    if(type=="USB"){ type = "drive-removable-media-usb"; }
+    else if(type=="HDRIVE" || type=="LVM"){ type = "drive-harddisk"; }
+    else if(type=="SDCARD"){ type = "media-flash-sd-mmc"; }
+    else if(type=="DVD"){ type = "media-optical"; }
+    else{ type = "drive-removable-media"; }
+    act->setIcon( LXDG::findIcon(type, "") );
       ui->menuExternal_Devices->addAction(act);
   }
 }
@@ -473,8 +473,8 @@ DirWidget* MainUI::FindActiveBrowser(){
 //    PRIVATE SLOTS
 //==============
 void MainUI::DisplayStatusBar(QString msg){
-	//qDebug() << "message to show in the status bar:" << msg;
-	ui->statusbar->showMessage(msg);
+    //qDebug() << "message to show in the status bar:" << msg;
+    ui->statusbar->showMessage(msg);
 }
 
 //---------------------
@@ -506,6 +506,11 @@ void MainUI::on_actionClose_triggered(){
   }
   qDebug() << "Closing Down...";
   this->close();
+}
+
+void MainUI::on_actionNew_Dir_triggered()
+{
+    DirWidget::createNewFolder(this, DWLIST.at( tabBar->currentIndex())->currentBrowser() );
 }
 
 void MainUI::on_actionRefresh_triggered(){
@@ -667,8 +672,8 @@ void MainUI::sortModeDateC(bool active){
     for(int i=0; i<tabBar->count(); i++){
       //Remove all the browser tabs
       if( !tabBar->tabWhatsThis(i).startsWith("#") ){
-	tabBar->removeTab(i);
-	i--; //go back one to ensure nothing is missed
+    tabBar->removeTab(i);
+    i--; //go back one to ensure nothing is missed
       }
     }
     //Create all the specific browser tabs for open browsers
@@ -684,8 +689,8 @@ void MainUI::sortModeDateC(bool active){
     for(int i=0; i<tabBar->count(); i++){
       //Remove all the browser tabs
       if( !tabBar->tabWhatsThis(i).startsWith("#") ){
-	tabBar->removeTab(i);
-	i--; //go back one to ensure nothing is missed
+    tabBar->removeTab(i);
+    i--; //go back one to ensure nothing is missed
       }
     }
     //Now create the generic "browser" tab
@@ -717,7 +722,7 @@ void MainUI::CreateBookMark(){
   QString dir = FindActiveBrowser()->currentDir();
   bool ok = false;
   QString name = QInputDialog::getText(this, tr("New Bookmark"), tr("Name:"), QLineEdit::Normal, dir, \
-		&ok, 0, Qt::ImhFormattedNumbersOnly | Qt::ImhUppercaseOnly | Qt::ImhLowercaseOnly);
+        &ok, 0, Qt::ImhFormattedNumbersOnly | Qt::ImhUppercaseOnly | Qt::ImhLowercaseOnly);
   if(!ok || name.isEmpty()){ return; } //cancelled
   QStringList BM = settings->value("bookmarks",QStringList()).toStringList();
   if(BM.filter(name+"::::").length() >0){
@@ -766,12 +771,12 @@ void MainUI::tabChanged(int tab){
     ui->stackedWidget->setCurrentWidget(ui->page_browser);
     //if(radio_view_tabs->isChecked()){
       for(int i=0; i<DWLIST.length(); i++){
-	 DWLIST[i]->setVisible(DWLIST[i]->id()==info);
+     DWLIST[i]->setVisible(DWLIST[i]->id()==info);
       }
     /*}else{
       //For columns, all widgets need to be visible
       for(int i=0; i<DWLIST.length(); i++){
-	 DWLIST[i]->setVisible(true);
+     DWLIST[i]->setVisible(true);
       }
     }*/
   }
@@ -787,9 +792,9 @@ void MainUI::tabClosed(int tab){
    if(!info.startsWith("#")){
     for(int i=0; i<DWLIST.length(); i++){
       if(info == DWLIST[i]->id()){
-	 DWLIST[i]->cleanup();
+     DWLIST[i]->cleanup();
         delete DWLIST.takeAt(i);
-	break;
+    break;
       }
     }
    }else if(info=="#MW"){
@@ -886,9 +891,9 @@ void MainUI::CutFiles(QStringList list){
   }
   //Now save that data to the global clipboard
   QMimeData *dat = new QMimeData;
-	dat->clear();
-	dat->setData("x-special/lumina-copied-files", list.join("\n").toLocal8Bit());
-	dat->setUrls(urilist); //the text/uri-list mimetype - built in Qt conversion/use
+    dat->clear();
+    dat->setData("x-special/lumina-copied-files", list.join("\n").toLocal8Bit());
+    dat->setUrls(urilist); //the text/uri-list mimetype - built in Qt conversion/use
   QApplication::clipboard()->clear();
   QApplication::clipboard()->setMimeData(dat);
   //Update all the buttons to account for clipboard change
@@ -906,9 +911,9 @@ void MainUI::CopyFiles(QStringList list){
   }
   //Now save that data to the global clipboard
   QMimeData *dat = new QMimeData;
-	dat->clear();
-	dat->setData("x-special/lumina-copied-files", list.join("\n").toLocal8Bit());
-	dat->setUrls(urilist); //the text/uri-list mimetype - built in Qt conversion/use
+    dat->clear();
+    dat->setData("x-special/lumina-copied-files", list.join("\n").toLocal8Bit());
+    dat->setUrls(urilist); //the text/uri-list mimetype - built in Qt conversion/use
   QApplication::clipboard()->clear();
   QApplication::clipboard()->setMimeData(dat);
   //Update all the buttons to account for clipboard change
@@ -926,12 +931,12 @@ void MainUI::PasteFiles(QString dir, QStringList raw){
   if(!dir.endsWith("/")){ dir.append("/"); }
   for(int i=0; i<raw.length(); i++){
     if(raw[i].startsWith("cut::::")){
-	cut << raw[i].section("::::",1,50);
-	newcut << dir+raw[i].section("::::",1,50).section("/",-1);
+    cut << raw[i].section("::::",1,50);
+    newcut << dir+raw[i].section("::::",1,50).section("/",-1);
     }
     else if(raw[i].startsWith("copy::::")){
-	copy << raw[i].section("::::",1,50);
-	newcopy<< dir+raw[i].section("::::",1,50).section("/",-1);
+    copy << raw[i].section("::::",1,50);
+    newcopy<< dir+raw[i].section("::::",1,50).section("/",-1);
     }
   }
   //bool errs = false;
@@ -963,9 +968,9 @@ void MainUI::PasteFiles(QString dir, QStringList raw){
     if(!copy.isEmpty()){
       //There were also files copied: save those files back into the clipboard
        QMimeData *dat = new QMimeData;
-	dat->clear();
-	dat->setData("x-special/lumina-copied-files", raw.filter("copy::::").join("\n").toLocal8Bit());
-	QApplication::clipboard()->setMimeData(dat);
+    dat->clear();
+    dat->setData("x-special/lumina-copied-files", raw.filter("copy::::").join("\n").toLocal8Bit());
+    QApplication::clipboard()->setMimeData(dat);
     }
   }
   //Update all the buttons to account for clipboard change

--- a/src-qt5/desktop-utils/lumina-fm/MainUI.h
+++ b/src-qt5/desktop-utils/lumina-fm/MainUI.h
@@ -60,144 +60,145 @@
 #include "widgets/DirWidget2.h"
 
 namespace Ui{
-	class MainUI;
+    class MainUI;
 };
 
 class MainUI : public QMainWindow{
-	Q_OBJECT
+    Q_OBJECT
 public:
-	MainUI();
-	~MainUI();
+    MainUI();
+    ~MainUI();
     //bool rootmode;
 
 public slots:
-	void OpenDirs(QStringList);	 //also called from the main.cpp after initialization
-	void setupIcons(); 			//used during initialization
+    void OpenDirs(QStringList);	 //also called from the main.cpp after initialization
+    void setupIcons(); 			//used during initialization
 
 private:
-	Ui::MainUI *ui;
-	QThread *workThread;
-	DirData *worker;
-	//Internal non-ui widgets
-	QTabBar *tabBar;
-	//QFileSystemModel *fsmod;
-	QMenu *contextMenu, * menuSort_Mode;
+    Ui::MainUI *ui;
+    QThread *workThread;
+    DirData *worker;
+    //Internal non-ui widgets
+    QTabBar *tabBar;
+    //QFileSystemModel *fsmod;
+    QMenu *contextMenu, * menuSort_Mode;
     QRadioButton *radio_view_details, *radio_view_list, *radio_sort_name, *radio_sort_size, *radio_sort_type, *radio_sort_datemod, *radio_sort_datecre;//, *radio_view_tabs, *radio_view_cols;
     QWidgetAction *detWA, *listWA, *sortnameA, *sortsizeA, *sorttypeA, *sortdateMA, *sortdateCA; //, *tabsWA, *colsWA;
 
-	//UI Widgets
-	QList<DirWidget*> DWLIST;
-	MultimediaWidget *MW;
-	SlideshowWidget *SW;
-	TrayUI *TRAY;
-	bool waitingToClose;
+    //UI Widgets
+    QList<DirWidget*> DWLIST;
+    MultimediaWidget *MW;
+    SlideshowWidget *SW;
+    TrayUI *TRAY;
+    bool waitingToClose;
 
-	QSettings *settings;
-	QShortcut *nextTabLShort, *nextTabRShort, *togglehiddenfilesShort, *focusDirWidgetShort;
-	//QShortcut *toggledirtreepaneShort;
-	//QCompleter *dirCompleter;
+    QSettings *settings;
+    QShortcut *nextTabLShort, *nextTabRShort, *togglehiddenfilesShort, *focusDirWidgetShort;
+    //QShortcut *toggledirtreepaneShort;
+    //QCompleter *dirCompleter;
 
-	//Simplification Functions
-	void setupConnections(); 	//used during initialization
-	void loadSettings(); 		//used during initialization
+    //Simplification Functions
+    void setupConnections(); 	//used during initialization
+    void loadSettings(); 		//used during initialization
 
-	void RebuildBookmarksMenu();
-	void RebuildDeviceMenu();
+    void RebuildBookmarksMenu();
+    void RebuildDeviceMenu();
 
-	DirWidget* FindActiveBrowser();
+    DirWidget* FindActiveBrowser();
 
 private slots:
-	void slotSingleInstance(QStringList in){
-	  this->show();
-	  this->raise();
-	  this->activateWindow();
-	  this->OpenDirs(in);
-	}
+    void slotSingleInstance(QStringList in){
+      this->show();
+      this->raise();
+      this->activateWindow();
+      this->OpenDirs(in);
+    }
 
-	//void slotStartSyncTimer();
+    //void slotStartSyncTimer();
 
-	//Menu Actions
-	void on_actionNew_Window_triggered();
-	void on_actionNew_Tab_triggered();
-	void on_actionSearch_triggered();
-	void on_actionClose_Browser_triggered();
-	void on_actionClose_triggered();
-	/*void on_actionRename_triggered();
-	void on_actionCut_Selection_triggered();
-	void on_actionCopy_Selection_triggered();
-	void on_actionPaste_triggered();
-	void on_actionDelete_Selection_triggered();*/
-	void on_actionRefresh_triggered();
-	void on_actionView_Hidden_Files_triggered();
-	void on_actionVerify_File_Delete_triggered();
-	//void on_actionView_showDirTreePane_triggered();
-	//void on_actionShow_Action_Buttons_triggered();
-	void treeWidgetWidthChanged(float percent);
-	void on_actionShow_Thumbnails_triggered();
-	void goToBookmark(QAction*);
-	void goToDevice(QAction*);
-	void viewModeChanged(bool);
+    //Menu Actions
+    void on_actionNew_Window_triggered();
+    void on_actionNew_Tab_triggered();
+    void on_actionSearch_triggered();
+    void on_actionClose_Browser_triggered();
+    void on_actionClose_triggered();
+    void on_actionNew_Dir_triggered();
+    /*void on_actionRename_triggered();
+    void on_actionCut_Selection_triggered();
+    void on_actionCopy_Selection_triggered();
+    void on_actionPaste_triggered();
+    void on_actionDelete_Selection_triggered();*/
+    void on_actionRefresh_triggered();
+    void on_actionView_Hidden_Files_triggered();
+    void on_actionVerify_File_Delete_triggered();
+    //void on_actionView_showDirTreePane_triggered();
+    //void on_actionShow_Action_Buttons_triggered();
+    void treeWidgetWidthChanged(float percent);
+    void on_actionShow_Thumbnails_triggered();
+    void goToBookmark(QAction*);
+    void goToDevice(QAction*);
+    void viewModeChanged(bool);
     void sortModeName(bool);
     void sortModeSize(bool);
     void sortModeType(bool);
    void sortModeDateM(bool);
    void sortModeDateC(bool);
- 
-	//void groupModeChanged(bool);
-	void on_actionLarger_Icons_triggered();
-	void on_actionSmaller_Icons_triggered();
-	void CreateBookMark();
-	//Git Menu options
-	void on_menuGit_aboutToShow();
-	void on_actionRepo_Status_triggered();
-	void on_actionClone_Repository_triggered();
 
-	//Tab interactions
-	void tabChanged(int tab = -1);
-	void tabClosed(int tab = -1);
-	void nextTab(); //For keyboard shortcuts
-	void prevTab(); //For keyboard shortcuts
+    //void groupModeChanged(bool);
+    void on_actionLarger_Icons_triggered();
+    void on_actionSmaller_Icons_triggered();
+    void CreateBookMark();
+    //Git Menu options
+    void on_menuGit_aboutToShow();
+    void on_actionRepo_Status_triggered();
+    void on_actionClone_Repository_triggered();
 
-	//Other Shortcuts
-	void togglehiddenfiles();
-	//void toggleDirTreePane();
-	void focusDirWidget();
+    //Tab interactions
+    void tabChanged(int tab = -1);
+    void tabClosed(int tab = -1);
+    void nextTab(); //For keyboard shortcuts
+    void prevTab(); //For keyboard shortcuts
 
-	//Backend Info passing
-	//void DirDataAvailable(QString, QString, LFileInfoList);
-	void SnapshotDataAvailable(QString, QString, QStringList);
+    //Other Shortcuts
+    void togglehiddenfiles();
+    //void toggleDirTreePane();
+    void focusDirWidget();
 
-	//Dir Browser Interactions
-	void OpenPlayer(LFileInfoList);
-	void OpenImages(LFileInfoList);
-	void OpenTerminal(QString dirpath);
-	void CutFiles(QStringList); //file selection
-	void CopyFiles(QStringList); //file selection
-	void PasteFiles(QString, QStringList raw = QStringList() ); //current dir, optional list of commands
-	void FavoriteFiles(QStringList); //file selection
-	void RenameFiles(QStringList); //file selection
-	void RemoveFiles(QStringList); //file selection
-	void CloseBrowser(QString); //ID
-	void TabNameChanged(QString, QString); // ID/name
+    //Backend Info passing
+    //void DirDataAvailable(QString, QString, LFileInfoList);
+    void SnapshotDataAvailable(QString, QString, QStringList);
 
-	//file info in status bar
-	void DisplayStatusBar(QString);
+    //Dir Browser Interactions
+    void OpenPlayer(LFileInfoList);
+    void OpenImages(LFileInfoList);
+    void OpenTerminal(QString dirpath);
+    void CutFiles(QStringList); //file selection
+    void CopyFiles(QStringList); //file selection
+    void PasteFiles(QString, QStringList raw = QStringList() ); //current dir, optional list of commands
+    void FavoriteFiles(QStringList); //file selection
+    void RenameFiles(QStringList); //file selection
+    void RemoveFiles(QStringList); //file selection
+    void CloseBrowser(QString); //ID
+    void TabNameChanged(QString, QString); // ID/name
 
-	void TrayJobsFinished();
+    //file info in status bar
+    void DisplayStatusBar(QString);
+
+    void TrayJobsFinished();
 
     void on_actionOpen_as_Root_triggered();
 
 signals:
-	void Si_AdaptStatusBar(QFileInfoList fileList, QString path, QString messageFolders, QString messageFiles);
+    void Si_AdaptStatusBar(QFileInfoList fileList, QString path, QString messageFolders, QString messageFiles);
 
 protected:
-	void resizeEvent(QResizeEvent *ev){
-	  //Save the new size to the settings file for later
-	  settings->setValue("preferences/MainWindowSize", ev->size());
-	  QMainWindow::resizeEvent(ev); //just in case the window needs to see the event too
-	}
+    void resizeEvent(QResizeEvent *ev){
+      //Save the new size to the settings file for later
+      settings->setValue("preferences/MainWindowSize", ev->size());
+      QMainWindow::resizeEvent(ev); //just in case the window needs to see the event too
+    }
 
-	void closeEvent(QCloseEvent *ev);
+    void closeEvent(QCloseEvent *ev);
 
 };
 

--- a/src-qt5/desktop-utils/lumina-fm/MainUI.ui
+++ b/src-qt5/desktop-utils/lumina-fm/MainUI.ui
@@ -69,7 +69,7 @@
              <x>0</x>
              <y>0</y>
              <width>567</width>
-             <height>163</height>
+             <height>175</height>
             </rect>
            </property>
            <layout class="QHBoxLayout" name="BrowserLayout">
@@ -116,7 +116,7 @@
      <x>0</x>
      <y>0</y>
      <width>567</width>
-     <height>28</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -126,6 +126,8 @@
     <addaction name="actionNew_Window"/>
     <addaction name="actionNew_Tab"/>
     <addaction name="actionSearch"/>
+    <addaction name="separator"/>
+    <addaction name="actionNew_Dir"/>
     <addaction name="separator"/>
     <addaction name="actionClose_Browser"/>
     <addaction name="separator"/>
@@ -472,6 +474,20 @@
   <action name="actionSortTabs">
    <property name="text">
     <string>Sort by Name</string>
+   </property>
+  </action>
+  <action name="actionNew_Dir">
+   <property name="text">
+    <string>Create Directory</string>
+   </property>
+   <property name="toolTip">
+    <string>Create Directory</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+N</string>
+   </property>
+   <property name="shortcutContext">
+    <enum>Qt::WidgetWithChildrenShortcut</enum>
    </property>
   </action>
  </widget>

--- a/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.cpp
+++ b/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.cpp
@@ -246,7 +246,7 @@ void DirWidget::createShortcuts(){
   kZoomIn= new QShortcut(QKeySequence(QKeySequence::ZoomIn),this);
   kZoomOut= new QShortcut(QKeySequence(QKeySequence::ZoomOut),this);
   kNewFile= new QShortcut(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_F),this);
-  kNewDir= new QShortcut(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_N),this);
+  kNewDir= new QShortcut(QKeySequence(Qt::CTRL+Qt::SHIFT+Qt::Key_N), this);
   kNewXDG= new QShortcut(QKeySequence(Qt::CTRL+Qt::Key_G),this);
   kCut= new QShortcut(QKeySequence(QKeySequence::Cut),this);
   kCopy= new QShortcut(QKeySequence(QKeySequence::Copy),this);
@@ -592,11 +592,11 @@ void DirWidget::UpdateContextMenu(){
     }
     if(LUtils::isValidBinary("lumina-archiver") && sel.length() >=1 && canmodify){
       cArchiveMenu->clear();
-      if(sel.length()==1 && ( XDGMime::fromFileName(sel[0]).endsWith("-tar") || 
-                                                XDGMime::fromFileName(sel[0]).endsWith("-image") || 
-                                                 ( XDGMime::fromFileName(sel[0]).contains("zip") && 
-                                                   !XDGMime::fromFileName(sel[0]).endsWith("epub+zip") && 
-                                                   !XDGMime::fromFileName(sel[0]).endsWith("vnd.comicbook+zip" ) 
+      if(sel.length()==1 && ( XDGMime::fromFileName(sel[0]).endsWith("-tar") ||
+                                                XDGMime::fromFileName(sel[0]).endsWith("-image") ||
+                                                 ( XDGMime::fromFileName(sel[0]).contains("zip") &&
+                                                   !XDGMime::fromFileName(sel[0]).endsWith("epub+zip") &&
+                                                   !XDGMime::fromFileName(sel[0]).endsWith("vnd.comicbook+zip" )
                                                   )
                                                  )
                                                ){
@@ -738,27 +738,33 @@ void DirWidget::createNewFile(){
   }
 }
 
+
+void DirWidget::createNewFolder(QWidget *parent, BrowserWidget *browser){
+
+    //Prompt for the new dir name
+    bool ok = false;
+    QString newdir = QInputDialog::getText(parent, tr("New Directory"), tr("Name:"), QLineEdit::Normal, "", \
+          &ok, 0, Qt::ImhFormattedNumbersOnly | Qt::ImhUppercaseOnly | Qt::ImhLowercaseOnly);
+    if(!ok || newdir.isEmpty()){ return; }
+    //Now create the new dir
+    QString full = browser->currentDirectory();
+    if(!full.endsWith("/")){ full.append("/"); }
+    QDir dir(full); //open the current dir
+    full.append(newdir); //append the new name to the current dir
+    //Verify that the new dir does not already exist
+    if(dir.exists(full)){
+      QMessageBox::warning(parent, tr("Invalid Name"), tr("A file or directory with that name already exists! Please pick a different name."));
+      QTimer::singleShot(0,parent, SLOT(createNewDir(parent, browser)) ); //repeat this function
+    }else{
+      if(!dir.mkdir(newdir) ){
+        QMessageBox::warning(parent, tr("Error Creating Directory"), tr("The directory could not be created. Please ensure that you have the proper permissions to modify the current directory."));
+      }
+    }
+}
+
 void DirWidget::createNewDir(){
   if(!canmodify){ return; } //cannot create anything here
-  //Prompt for the new dir name
-  bool ok = false;
-  QString newdir = QInputDialog::getText(this, tr("New Directory"), tr("Name:"), QLineEdit::Normal, "", \
-        &ok, 0, Qt::ImhFormattedNumbersOnly | Qt::ImhUppercaseOnly | Qt::ImhLowercaseOnly);
-  if(!ok || newdir.isEmpty()){ return; }
-  //Now create the new dir
-  QString full = currentBrowser()->currentDirectory();
-  if(!full.endsWith("/")){ full.append("/"); }
-  QDir dir(full); //open the current dir
-  full.append(newdir); //append the new name to the current dir
-  //Verify that the new dir does not already exist
-  if(dir.exists(full)){
-    QMessageBox::warning(this, tr("Invalid Name"), tr("A file or directory with that name already exists! Please pick a different name."));
-    QTimer::singleShot(0,this, SLOT(createNewDir()) ); //repeat this function
-  }else{
-    if(!dir.mkdir(newdir) ){
-      QMessageBox::warning(this, tr("Error Creating Directory"), tr("The directory could not be created. Please ensure that you have the proper permissions to modify the current directory."));
-    }
-  }
+  createNewFolder(this, currentBrowser());
 }
 
 void DirWidget::createNewXDGEntry(){

--- a/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.h
+++ b/src-qt5/desktop-utils/lumina-fm/widgets/DirWidget2.h
@@ -25,76 +25,79 @@
 #define ZSNAPDIR QString("/.zfs/snapshot/")
 
 namespace Ui{
-	class DirWidget;
+    class DirWidget;
 };
 
 class DirWidget : public QWidget{
-	Q_OBJECT
+    Q_OBJECT
 public:
-	enum DETAILTYPES{ NAME, SIZE, TYPE, DATEMOD, DATECREATE};
-	DirWidget(QString objID, QSettings *settings, QWidget *parent = 0); //needs a unique ID (to distinguish from other DirWidgets)
-	~DirWidget();
+    enum DETAILTYPES{ NAME, SIZE, TYPE, DATEMOD, DATECREATE};
+    DirWidget(QString objID, QSettings *settings, QWidget *parent = 0); //needs a unique ID (to distinguish from other DirWidgets)
+    ~DirWidget();
 
-	void cleanup(); //called before the browser is closed down
+    void cleanup(); //called before the browser is closed down
 
-	//Directory Managment
-	void ChangeDir(QString dirpath);
-	void setDirCompleter(QCompleter *comp);
+    //Directory Managment
+    void ChangeDir(QString dirpath);
+    void setDirCompleter(QCompleter *comp);
 
-	//Information
-	QString id();
-	QString currentDir();
-	QFileSystemModel *dirtreeModel;
-	QStringList PREFAPPS;
+    //Information
+    QString id();
+    QString currentDir();
+    QFileSystemModel *dirtreeModel;
+    QStringList PREFAPPS;
 
-	//View Settings
-	void setShowDetails(bool show);
-	void showHidden(bool show);
-	void showThumbnails(bool show);
-	void setThumbnailSize(int px);
-	void setFocusLineDir();
-	void adjustTreeWidget(float percent); //percent between 0-100
-	void setTreeSortMode(int num); //0-4
+    //View Settings
+    void setShowDetails(bool show);
+    void showHidden(bool show);
+    void showThumbnails(bool show);
+    void setThumbnailSize(int px);
+    void setFocusLineDir();
+    void adjustTreeWidget(float percent); //percent between 0-100
+    void setTreeSortMode(int num); //0-4
+    BrowserWidget* currentBrowser();
+
+    static void createNewFolder(QWidget *parent, BrowserWidget *browser);
 
 
 public slots:
-	//void LoadDir(QString dir, LFileInfoList list);
-	void LoadSnaps(QString basedir, QStringList snaps);
+    //void LoadDir(QString dir, LFileInfoList list);
+    void LoadSnaps(QString basedir, QStringList snaps);
 
-	//Refresh options
-	void refresh(); //Refresh current directory
+    //Refresh options
+    void refresh(); //Refresh current directory
 
-	//Theme change functions
-	void UpdateIcons();
-	void UpdateText();
+    //Theme change functions
+    void UpdateIcons();
+    void UpdateText();
+
 
 
 private:
-	Ui::DirWidget *ui;
-	BrowserWidget *BW, *RCBW; //Main BrowserWidget and right-column browser widget
-	QString ID, cBID; //unique ID assigned by the parent, and currently active browser widget
-	QString normalbasedir, snapbasedir, snaprelpath, rootfmdir; //for maintaining directory context while moving between snapshots
-	QStringList snapshots, needThumbs, tmpSel;
-	QSettings *settings;
-	bool canmodify;
+    Ui::DirWidget *ui;
+    BrowserWidget *BW, *RCBW; //Main BrowserWidget and right-column browser widget
+    QString ID, cBID; //unique ID assigned by the parent, and currently active browser widget
+    QString normalbasedir, snapbasedir, snaprelpath, rootfmdir; //for maintaining directory context while moving between snapshots
+    QStringList snapshots, needThumbs, tmpSel;
+    QSettings *settings;
+    bool canmodify;
 
-	//The Toolbar and associated items
-	QToolBar *toolbar;
-	QLineEdit *line_dir;
+    //The Toolbar and associated items
+    QToolBar *toolbar;
+    QLineEdit *line_dir;
 
-	//The context menu and associated items
-	QMenu *contextMenu, *cNewMenu, *cOpenMenu, *cFModMenu, *cFViewMenu, *cOpenWithMenu, *cArchiveMenu;
+    //The context menu and associated items
+    QMenu *contextMenu, *cNewMenu, *cOpenMenu, *cFModMenu, *cFViewMenu, *cOpenWithMenu, *cArchiveMenu;
 
-	//The keyboard shortcuts for context menu items
-	QShortcut *kZoomIn, *kZoomOut, *kNewFile, *kNewDir, *kNewXDG, *kCut, *kCopy, *kPaste, *kRename, \
+    //The keyboard shortcuts for context menu items
+    QShortcut *kZoomIn, *kZoomOut, *kNewFile, *kNewDir, *kNewXDG, *kCut, *kCopy, *kPaste, *kRename, \
         *kFav, *kDel, *kOpSS, *kOpMM, *kOpTerm, *kExtract, *kArchive;
 
-	//Functions for internal use
-	void createShortcuts(); //on init only
-	void createMenus(); //on init only
+    //Functions for internal use
+    void createShortcuts(); //on init only
+    void createMenus(); //on init only
 
-	BrowserWidget* currentBrowser();
-	QStringList currentDirFiles(); //all the "files" available within the current dir/browser
+    QStringList currentDirFiles(); //all the "files" available within the current dir/browser
 
   //QProcess *pExtract;
   //OpenWithMenu
@@ -103,93 +106,93 @@ private:
   //QStringList getPreferredApplications();
 
 private slots:
-	//UI BUTTONS/Actions
-	void splitterMoved();
+    //UI BUTTONS/Actions
+    void splitterMoved();
 
-	// -- Bottom Action Buttons
-	void on_tool_zoom_in_clicked();
-	void on_tool_zoom_out_clicked();
+    // -- Bottom Action Buttons
+    void on_tool_zoom_in_clicked();
+    void on_tool_zoom_out_clicked();
 
-	// -- Top Snapshot Buttons
-	void on_tool_snap_newer_clicked();
-	void on_tool_snap_older_clicked();
-	void on_slider_snap_valueChanged(int val = -1);
-	void direct_snap_selected(QAction*);
+    // -- Top Snapshot Buttons
+    void on_tool_snap_newer_clicked();
+    void on_tool_snap_older_clicked();
+    void on_slider_snap_valueChanged(int val = -1);
+    void direct_snap_selected(QAction*);
 
-	//Top Toolbar buttons
-	void on_actionBack_triggered();
-	void on_actionUp_triggered();
-	void on_actionHome_triggered();
-	void dir_changed(); //user manually changed the directory
-	void on_actionSingleColumn_triggered(bool);
-	void on_actionDualColumn_triggered(bool);
-	void on_actionMenu_triggered();
+    //Top Toolbar buttons
+    void on_actionBack_triggered();
+    void on_actionUp_triggered();
+    void on_actionHome_triggered();
+    void dir_changed(); //user manually changed the directory
+    void on_actionSingleColumn_triggered(bool);
+    void on_actionDualColumn_triggered(bool);
+    void on_actionMenu_triggered();
 
-	// - Other Actions without a specific button on the side
-	void fileCheckSums();
-	void fileProperties();
-	void openTerminal();
-	void openRootFM();
+    // - Other Actions without a specific button on the side
+    void fileCheckSums();
+    void fileProperties();
+    void openTerminal();
+    void openRootFM();
 
 
-	//Browser Functions
-	void OpenContextMenu();
-	void UpdateContextMenu();
-	void currentDirectoryChanged(QString dir, bool widgetonly = false);
-	void currentDirectoryChanged(bool widgetonly = false);
-	void dirStatusChanged(QString);
-	void setCurrentBrowser(QString);
-	void on_folderViewPane_clicked(const QModelIndex &index);
+    //Browser Functions
+    void OpenContextMenu();
+    void UpdateContextMenu();
+    void currentDirectoryChanged(QString dir, bool widgetonly = false);
+    void currentDirectoryChanged(bool widgetonly = false);
+    void dirStatusChanged(QString);
+    void setCurrentBrowser(QString);
+    void on_folderViewPane_clicked(const QModelIndex &index);
 
-	//Context Menu Functions
-	// - DIRECTORY operations
-	void createNewFile();
-	void createNewDir();
-	void createNewXDGEntry();
-	//void createNewSymlink();
+    //Context Menu Functions
+    // - DIRECTORY operations
+    void createNewFile();
+    void createNewDir();
+    void createNewXDGEntry();
+    //void createNewSymlink();
 
-	// - Selected FILE operations
-	void cutFiles();
-	void copyFiles();
-	void pasteFiles();
-	void renameFiles();
-	void favoriteFiles();
-	void removeFiles();
-	void runFiles();
-	void runWithFiles();
-	//void attachToNewEmail();
-	void autoExtractFiles();
-	void autoArchiveFiles();
-	void setAsWallpaper();
+    // - Selected FILE operations
+    void cutFiles();
+    void copyFiles();
+    void pasteFiles();
+    void renameFiles();
+    void favoriteFiles();
+    void removeFiles();
+    void runFiles();
+    void runWithFiles();
+    //void attachToNewEmail();
+    void autoExtractFiles();
+    void autoArchiveFiles();
+    void setAsWallpaper();
 
-	// - Context-specific operations
-	void openInSlideshow();
-	void openMultimedia();
-	void OpenWithApp(QAction*);
+    // - Context-specific operations
+    void openInSlideshow();
+    void openMultimedia();
+    void OpenWithApp(QAction*);
 
 signals:
-	//Directory loading/finding signals
-	void OpenDirectories(QStringList); //Directories to open in other tabs/columns
-	void findSnaps(QString, QString); //ID, dirpath (Request snapshot information for a directory)
-	void CloseBrowser(QString); //ID (Request that this browser be closed)
-	void treeWidgetSizeChanged(float); //percent width
+    //Directory loading/finding signals
+    void OpenDirectories(QStringList); //Directories to open in other tabs/columns
+    void findSnaps(QString, QString); //ID, dirpath (Request snapshot information for a directory)
+    void CloseBrowser(QString); //ID (Request that this browser be closed)
+    void treeWidgetSizeChanged(float); //percent width
 
-	//External App/Widget launching
-	void PlayFiles(LFileInfoList); //open in multimedia player
-	void ViewFiles(LFileInfoList); //open in slideshow
-	void LaunchTerminal(QString); //dirpath
+    //External App/Widget launching
+    void PlayFiles(LFileInfoList); //open in multimedia player
+    void ViewFiles(LFileInfoList); //open in slideshow
+    void LaunchTerminal(QString); //dirpath
 
-	//System Interactions
-	void CutFiles(QStringList); //file selection
-	void CopyFiles(QStringList); //file selection
-	void PasteFiles(QString, QStringList); //current dir
-	void FavoriteFiles(QStringList); //file selection
-	void RenameFiles(QStringList); //file selection
-	void RemoveFiles(QStringList); //file selection
-	void TabNameChanged(QString, QString); //objID, new tab name
+    //System Interactions
+    void CutFiles(QStringList); //file selection
+    void CopyFiles(QStringList); //file selection
+    void PasteFiles(QString, QStringList); //current dir
+    void FavoriteFiles(QStringList); //file selection
+    void RenameFiles(QStringList); //file selection
+    void RemoveFiles(QStringList); //file selection
+    void TabNameChanged(QString, QString); //objID, new tab name
 
 protected:
-	void mouseReleaseEvent(QMouseEvent *);
+    void mouseReleaseEvent(QMouseEvent *);
 
 };
 


### PR DESCRIPTION
Even if it is possible to create a folder with the shortcut or a right click, I am a little confused not to have an action in the menu like in other FM.

This PR proposes its addition while keeping the shortcut Ctrl+Shift+N

A future improvement may be to add the creation of files in the menu.