### PR TITLE
Some changes and fixes to LuminaPDF

### DIFF
--- a/src-qt5/core/libLumina/LFileInfo.cpp
+++ b/src-qt5/core/libLumina/LFileInfo.cpp
@@ -267,7 +267,7 @@ bool LFileInfo::canZFSclone(){
   return (zfs_perms.contains("clone")  || (c_uid==0) );
 }
 
-bool LFileInfo::zfsCloneDataset(QString subdir, QString newsubdir){
+bool LFileInfo::zfsCloneDataset([[maybe_unused]] QString subdir, [[maybe_unused]] QString newsubdir){
   if(!canZFSclone()){ return false; }
 
   return false;

--- a/src-qt5/desktop-utils/lumina-pdf/Annotation.h
+++ b/src-qt5/desktop-utils/lumina-pdf/Annotation.h
@@ -1,46 +1,52 @@
+#include <QColor>
 #include <QList>
-#include <QVector>
 #include <QPointF>
 #include <QPolygonF>
+#include <QVector>
 
-class Annotation{
-  public:
-    Annotation(int _annotType, double _opacity, QRectF _loc = QRectF()) : annotType(_annotType), opacity(_opacity), loc(_loc) { }
+class Annotation {
+public:
+  Annotation(int _annotType, double _opacity, QRectF _loc = QRectF())
+      : annotType(_annotType), opacity(_opacity), loc(_loc) {}
 
-    virtual ~Annotation() { }
+  virtual ~Annotation() {}
 
-    virtual int getType() { return annotType; }
-    virtual QRectF getLoc() { return loc; }
+  virtual int getType() { return annotType; }
+  virtual QRectF getLoc() { return loc; }
 
-    virtual QString getAuthor() { return author; }
-    virtual QString getText() { return text; }
-    virtual QList<QPolygonF> getQuadList() { return quadList; }
-    virtual QVector<QVector<QPointF>> getInkList() { return inkList; }
-    virtual QColor getColor() { return color; }
-    virtual QColor getInternalColor() { return iColor; }
-    virtual double getOpacity() { return opacity; }
-    virtual bool print() { return canPrint; }
+  virtual QString getAuthor() { return author; }
+  virtual QString getText() { return text; }
+  virtual QList<QPolygonF> getQuadList() { return quadList; }
+  virtual QVector<QVector<QPointF>> getInkList() { return inkList; }
+  virtual QColor getColor() { return color; }
+  virtual QColor getInternalColor() { return iColor; }
+  virtual double getOpacity() { return opacity; }
+  virtual bool print() { return canPrint; }
 
-    virtual void setAuthor(QString _author) { author = _author; }
-    virtual void setContents(QString _text) { text = _text; }
-    virtual void setColor(QColor _color) { color = _color; };
-    virtual void setInternalColor(QColor _iColor) { iColor = _iColor; };
-    virtual void setQuadList(QList<QPolygonF> _quadList) { quadList = _quadList; };
-    virtual void setInkList(QVector<QVector<QPointF>> _inkList) { inkList = _inkList; };
-    virtual void setPrint(bool _print) { canPrint = _print; }
+  virtual void setAuthor(QString _author) { author = _author; }
+  virtual void setContents(QString _text) { text = _text; }
+  virtual void setColor(QColor _color) { color = _color; };
+  virtual void setInternalColor(QColor _iColor) { iColor = _iColor; };
+  virtual void setQuadList(QList<QPolygonF> _quadList) {
+    quadList = _quadList;
+  };
+  virtual void setInkList(QVector<QVector<QPointF>> _inkList) {
+    inkList = _inkList;
+  };
+  virtual void setPrint(bool _print) { canPrint = _print; }
 
-    virtual QImage renderImage() = 0;
+  virtual QImage renderImage() = 0;
 
-  private:
-    int annotType;
-    double opacity;
-    QRectF loc;
+private:
+  int annotType;
+  double opacity;
+  QRectF loc;
 
-    QString author;
-    QString text;
-    QColor color;
-    QColor iColor;
-    QList<QPolygonF> quadList;
-    QVector<QVector<QPointF>> inkList;
-    bool canPrint;
+  QString author;
+  QString text;
+  QColor color;
+  QColor iColor;
+  QList<QPolygonF> quadList;
+  QVector<QVector<QPointF>> inkList;
+  bool canPrint;
 };

--- a/src-qt5/desktop-utils/lumina-pdf/Bookmark.h
+++ b/src-qt5/desktop-utils/lumina-pdf/Bookmark.h
@@ -1,17 +1,15 @@
 #pragma once
 
 class Bookmark {
-  public:
-    Bookmark(char *_title, char *_link, int _pagenum, int _level) :
-      pagenum(_pagenum),
-      level(_level)
-    {
-      title = QString::fromLocal8Bit(_title);
-      link = QString::fromLocal8Bit(_link);
-    }
+public:
+  Bookmark(char *_title, char *_link, int _pagenum, int _level)
+      : pagenum(_pagenum), level(_level) {
+    title = QString::fromLocal8Bit(_title);
+    link = QString::fromLocal8Bit(_link);
+  }
 
-    QString title;
-    QString link;
-    int pagenum;
-    int level;
+  QString title;
+  QString link;
+  int pagenum;
+  int level;
 };

--- a/src-qt5/desktop-utils/lumina-pdf/BookmarkMenu.cpp
+++ b/src-qt5/desktop-utils/lumina-pdf/BookmarkMenu.cpp
@@ -8,42 +8,48 @@
 #include "BookmarkMenu.h"
 #include "ui_BookmarkMenu.h"
 #include <LuminaXDG.h>
-#include <QSplitter>
 #include <QPushButton>
+#include <QSplitter>
 
-BookmarkMenu::BookmarkMenu(Renderer *Backend, QWidget *parent) : QWidget(parent), ui(new Ui::BookmarkMenu()), BACKEND(Backend){
+BookmarkMenu::BookmarkMenu(Renderer *Backend, QWidget *parent)
+    : QWidget(parent), ui(new Ui::BookmarkMenu()), BACKEND(Backend) {
   ui->setupUi(this);
-  connect(ui->closeButton, &QPushButton::clicked, parent, [=]() { static_cast<QSplitter*>(parent)->setSizes(QList<int>() << 0 << this->width()); });
-  connect(ui->closeButton, &QPushButton::clicked, parent, [=]() { });
-  connect(ui->bookmarks, &QTreeWidget::itemClicked, this, [=](QTreeWidgetItem *item) { 
-    Backend->handleLink(parent, item->data(1, Qt::UserRole).toString()); }); 
+  connect(ui->closeButton, &QPushButton::clicked, parent, [=]() {
+    static_cast<QSplitter *>(parent)->setSizes(QList<int>()
+                                               << 0 << this->width());
+  });
+  connect(ui->closeButton, &QPushButton::clicked, parent, [=]() {});
+  connect(ui->bookmarks, &QTreeWidget::itemClicked, this,
+          [=](QTreeWidgetItem *item) {
+            Backend->handleLink(parent, item->data(1, Qt::UserRole).toString());
+          });
 }
 
 void BookmarkMenu::loadBookmarks() {
-  QTreeWidgetItem *item=nullptr, *parent=nullptr;
-  QList<Bookmark*> bookmarks = BACKEND->getBookmarks();
+  QTreeWidgetItem *item = nullptr, *parent = nullptr;
+  QList<Bookmark *> bookmarks = BACKEND->getBookmarks();
 
-  if(ui->bookmarks->topLevelItemCount() != 0) {
+  if (ui->bookmarks->topLevelItemCount() != 0) {
     ui->bookmarks->clear();
   }
 
-  //Modfiy for more than 2 levels
-  if(bookmarks.empty()) {
+  // Modfiy for more than 2 levels
+  if (bookmarks.empty()) {
     item = new QTreeWidgetItem(ui->bookmarks);
     item->setText(0, "No Bookmarks");
     item->setData(1, Qt::UserRole, "");
     item->setIcon(0, LXDG::findIcon("bookmark-remove"));
-  }else{
-    foreach(Bookmark *bm, bookmarks) {
-      if(bm->level == 0) {
+  } else {
+    foreach (Bookmark *bm, bookmarks) {
+      if (bm->level == 0) {
         item = new QTreeWidgetItem(ui->bookmarks);
         parent = item;
-      }else{
+      } else {
         item = new QTreeWidgetItem(parent);
       }
       item->setText(0, bm->title);
       item->setData(1, Qt::UserRole, bm->link);
-      if(!bm->link.isEmpty())
+      if (!bm->link.isEmpty())
         item->setIcon(0, LXDG::findIcon("bookmark-new"));
       else
         item->setIcon(0, LXDG::findIcon("bookmark-remove"));

--- a/src-qt5/desktop-utils/lumina-pdf/BookmarkMenu.h
+++ b/src-qt5/desktop-utils/lumina-pdf/BookmarkMenu.h
@@ -6,22 +6,22 @@
 //===========================================
 #pragma once
 
+#include "Renderer.h"
 #include <QDialog>
 #include <QTextEdit>
-#include "Renderer.h"
 
-namespace Ui{
-  class BookmarkMenu;
+namespace Ui {
+class BookmarkMenu;
 };
 
-class BookmarkMenu : public QWidget{
+class BookmarkMenu : public QWidget {
   Q_OBJECT
-  public:
-    BookmarkMenu(Renderer *Backend, QWidget *parent=NULL);
-  public slots:
-    void loadBookmarks();
+public:
+  BookmarkMenu(Renderer *Backend, QWidget *parent = NULL);
+public slots:
+  void loadBookmarks();
 
-  private:
-    Ui::BookmarkMenu *ui;
-    Renderer *BACKEND;
+private:
+  Ui::BookmarkMenu *ui;
+  Renderer *BACKEND;
 };

--- a/src-qt5/desktop-utils/lumina-pdf/PresentationLabel.h
+++ b/src-qt5/desktop-utils/lumina-pdf/PresentationLabel.h
@@ -10,25 +10,29 @@
 #ifndef _PRESENTATION_LABEL_WIDGET_H
 #define _PRESENTATION_LABEL_WIDGET_H
 
+#include <QDebug>
 #include <QLabel>
 #include <QMouseEvent>
-#include <QDebug>
 
-class PresentationLabel : public QLabel{
+class PresentationLabel : public QLabel {
   Q_OBJECT
 
 signals:
   void nextSlide();
 
 public:
-  PresentationLabel() : QLabel(0, Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint){
+  PresentationLabel()
+      : QLabel(0, Qt::Window | Qt::FramelessWindowHint |
+                      Qt::WindowStaysOnTopHint) {
     this->setContextMenuPolicy(Qt::CustomContextMenu);
   }
 
 protected:
-  void mousePressEvent(QMouseEvent *ev){
+  void mousePressEvent(QMouseEvent *ev) {
     QLabel::mousePressEvent(ev);
-    if(ev->button()==Qt::LeftButton){ emit nextSlide(); }
+    if (ev->button() == Qt::LeftButton) {
+      emit nextSlide();
+    }
   }
 };
 

--- a/src-qt5/desktop-utils/lumina-pdf/PrintWidget.cpp
+++ b/src-qt5/desktop-utils/lumina-pdf/PrintWidget.cpp
@@ -1,23 +1,27 @@
 #include "PrintWidget.h"
-#include <QPushButton>
 #include <QGraphicsProxyWidget>
+#include <QPushButton>
 
-PrintWidget::PrintWidget(Renderer *backend, QWidget *parent) : 
-  QGraphicsView(parent), scene(0), curPage(1), viewMode(SinglePageView), 
-  zoomMode(FitInView), zoomFactor(1), initialized(false), fitting(true), BACKEND(backend) {
+PrintWidget::PrintWidget(Renderer *backend, QWidget *parent)
+    : QGraphicsView(parent), scene(0), curPage(1), viewMode(SinglePageView),
+      zoomMode(FitInView), zoomFactor(1), initialized(false), fitting(true),
+      BACKEND(backend) {
 
   this->setMouseTracking(true);
-  QList<QWidget*> children = this->findChildren<QWidget*>("",Qt::FindChildrenRecursively);
-  for(int i=0; i<children.length(); i++){
+  QList<QWidget *> children =
+      this->findChildren<QWidget *>("", Qt::FindChildrenRecursively);
+  for (int i = 0; i < children.length(); i++) {
     children[i]->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(children[i], SIGNAL(customContextMenuRequested(const QPoint&)), this, SIGNAL(customContextMenuRequested(const QPoint&)) );
+    QObject::connect(children[i],
+                     SIGNAL(customContextMenuRequested(const QPoint &)), this,
+                     SIGNAL(customContextMenuRequested(const QPoint &)));
   }
   this->setInteractive(false);
   this->setDragMode(QGraphicsView::ScrollHandDrag);
   this->setViewportUpdateMode(QGraphicsView::SmartViewportUpdate);
   this->setFocusPolicy(Qt::NoFocus);
-  QObject::connect(this->verticalScrollBar(), SIGNAL(valueChanged(int)),
-                   this, SLOT(updateCurrentPage()));
+  QObject::connect(this->verticalScrollBar(), SIGNAL(valueChanged(int)), this,
+                   SLOT(updateCurrentPage()));
   QObject::connect(this, SIGNAL(resized()), this, SLOT(fit()));
 
   scene = new QGraphicsScene(this);
@@ -31,24 +35,24 @@ PrintWidget::PrintWidget(Renderer *backend, QWidget *parent) :
 }
 
 PrintWidget::~PrintWidget() {
-  for (int i = 0; i < pages.size(); i++){
+  for (int i = 0; i < pages.size(); i++) {
     scene->removeItem(pages.at(i));
   }
   qDeleteAll(pages);
-  pages.clear(); 
+  pages.clear();
   scene->deleteLater();
 }
 
-//Public Slots
+// Public Slots
 
 void PrintWidget::fitView() {
   setZoomMode(FitInView);
-  setCurrentPage(publicPageNum); //Make sure we stay on the same page
+  setCurrentPage(curPage); // Make sure we stay on the same page
 }
 
 void PrintWidget::fitToWidth() {
   setZoomMode(FitToWidth);
-  setCurrentPage(publicPageNum); //Make sure we stay on the same page
+  setCurrentPage(curPage); // Make sure we stay on the same page
 }
 
 void PrintWidget::setZoomMode(ZoomMode mode) {
@@ -57,17 +61,11 @@ void PrintWidget::setZoomMode(ZoomMode mode) {
   fit(true);
 }
 
-void PrintWidget::setAllPagesViewMode() {
-  setViewMode(AllPagesView);
-}
+void PrintWidget::setAllPagesViewMode() { setViewMode(AllPagesView); }
 
-void PrintWidget::setSinglePageViewMode() {
-  setViewMode(SinglePageView);
-}
+void PrintWidget::setSinglePageViewMode() { setViewMode(SinglePageView); }
 
-void PrintWidget::setFacingPagesViewMode() {
-  setViewMode(FacingPagesView);
-}
+void PrintWidget::setFacingPagesViewMode() { setViewMode(FacingPagesView); }
 
 void PrintWidget::setViewMode(ViewMode mode) {
   viewMode = mode;
@@ -94,7 +92,7 @@ void PrintWidget::zoomOut(double factor) {
   fitting = false;
   zoomMode = CustomZoom;
   zoomFactor *= factor;
-  this->scale(1/factor, 1/factor);
+  this->scale(1 / factor, 1 / factor);
 }
 
 void PrintWidget::updatePreview() {
@@ -104,48 +102,48 @@ void PrintWidget::updatePreview() {
 }
 
 void PrintWidget::setVisible(bool visible) {
-  if(visible and !initialized)
+  if (visible and !initialized)
     updatePreview();
   QGraphicsView::setVisible(visible);
 }
 
 void PrintWidget::setCurrentPage(int pageNumber) {
-  if(pageNumber < 0 || pageNumber > (pages.count()+1) ){ return; }
-  publicPageNum = pageNumber; //publicly requested page number (+/- 1 from actual page range)
-  emit currentPageChanged();
-  if(pageNumber < 1 || pageNumber > pages.count())
-    return;
-  int lastPage = curPage;
-  curPage = pageNumber;
 
-  if (lastPage != curPage && lastPage > 0 && lastPage <= pages.count()) {
+  int lastPage = curPage;
+  curPage = std::max(1, std::min(pageNumber, BACKEND->numPages()));
+
+  /* if (lastPage != curPage && lastPage > 0 && lastPage <= pages.count()) {
     if (zoomMode != FitInView) {
       QScrollBar *hsc = this->horizontalScrollBar();
       QScrollBar *vsc = this->verticalScrollBar();
-      QPointF pt = this->transform().map(pages.at(curPage-1)->pos());
+      QPointF pt = this->transform().map(pages.at(curPage - 1)->pos());
       vsc->setValue(int(pt.y()) - 10);
       hsc->setValue(int(pt.x()) - 10);
     } else {
-      this->centerOn(pages.at(curPage-1));
+      this->centerOn(pages.at(curPage - 1));
     }
-  }
+  } */
 
-  //qDebug() << "Page Set";
+  if (lastPage != curPage)
+    updatePreview();
+
+  qDebug() << "Current page set to " << pageNumber << "\n";
 }
 
 void PrintWidget::highlightText(TextData *text) {
-  //Creates a rectangle around the text if the text has not already been highlighted
-  //qDebug() << "Page:" << text->page() << "Loc:" << text->loc();
-  if(!text->highlighted() && !text->loc().isNull()) {
+  // Creates a rectangle around the text if the text has not already been
+  // highlighted qDebug() << "Page:" << text->page() << "Loc:" << text->loc();
+  if (!text->highlighted() && !text->loc().isNull()) {
     int degrees = BACKEND->rotatedDegrees();
-    //qDebug() << "Degrees:" << degrees;
-    //Shows the text's location on a non-rotated page
+    // qDebug() << "Degrees:" << degrees;
+    // Shows the text's location on a non-rotated page
     QRectF rect = text->loc();
-    //Rotates the rectangle by the page's center and gets the right calculation for text's new location
-    if(degrees != 0) {
-      QSize center = BACKEND->imageHash(text->page()-1).size()/2;
+    // Rotates the rectangle by the page's center and gets the right calculation
+    // for text's new location
+    if (degrees != 0) {
+      QSize center = BACKEND->imageSize(text->page() - 1) / 2;
 
-      if(degrees == 90 or degrees == 270)
+      if (degrees == 90 or degrees == 270)
         center.transpose();
 
       double cx = center.width(), cy = center.height();
@@ -153,24 +151,24 @@ void PrintWidget::highlightText(TextData *text) {
       QMatrix matrix;
       matrix.rotate(BACKEND->rotatedDegrees());
       rect = matrix.mapRect(rect);
-      if(BACKEND->rotatedDegrees() == 180)
+      if (BACKEND->rotatedDegrees() == 180)
         rect.adjust(cx, cy, cx, cy);
       else
         rect.adjust(cy, cx, cy, cx);
     }
 
-    //qDebug() << "Post Degrees:" << rect;
-    //Moves the rectangle onto the right page
+    // qDebug() << "Post Degrees:" << rect;
+    // Moves the rectangle onto the right page
     double pageHeight = 0;
-    for(int i = 0; i < text->page() - 1; i++)
+    for (int i = 0; i < text->page() - 1; i++)
       pageHeight += pages.at(i)->boundingRect().height();
 
-    //qDebug() << "PageHeight:" << pageHeight;
+    // qDebug() << "PageHeight:" << pageHeight;
 
     rect.moveTop(rect.y() + pageHeight);
 
-    //qDebug() << "Final Rect:" << rect;
-    //Transparent yellow for the highlight box
+    // qDebug() << "Final Rect:" << rect;
+    // Transparent yellow for the highlight box
     QBrush highlightFill(QColor(255, 255, 177, 100));
     QPen highlightOutline(QColor(255, 255, 100, 125));
     scene->addRect(rect, highlightOutline, highlightFill);
@@ -179,15 +177,17 @@ void PrintWidget::highlightText(TextData *text) {
   goToPosition(text->page(), text->loc().x(), text->loc().y());
 }
 
-//Private functions
+// Private functions
 
 void PrintWidget::generatePreview() {
   populateScene(); // i.e. setPreviewPrintedPictures() e.l.
   layoutPages();
-  curPage = qBound(1, curPage, pages.count());
+  // curPage = qBound(1, curPage, pages.count());
   publicPageNum = curPage;
   emit currentPageChanged();
-  if (fitting){ fit(); }
+  if (fitting) {
+    fit();
+  }
 }
 
 void PrintWidget::layoutPages() {
@@ -197,17 +197,18 @@ void PrintWidget::layoutPages() {
 
   int numPagePlaces = numPages;
   int cols = 1; // singleMode and default
-  QSize pageSize = BACKEND->imageHash(curPage-1).size();
+  QSize pageSize = BACKEND->imageSize(curPage);
   if (viewMode == AllPagesView) {
-    cols = pageSize.width() > pageSize.height() ? qFloor(qSqrt(numPages)) : qCeil(qSqrt(numPages));
-    cols += cols % 2;  // Nicer with an even number of cols
+    cols = pageSize.width() > pageSize.height() ? qFloor(qSqrt(numPages))
+                                                : qCeil(qSqrt(numPages));
+    cols += cols % 2; // Nicer with an even number of cols
   } else if (viewMode == FacingPagesView) {
     cols = 2;
     numPagePlaces += 1;
   }
   int rows = qCeil(double(numPagePlaces) / cols);
 
-  int pageNum = 0; 
+  int pageNum = 0;
   QList<double> rowMaxList;
   for (int i = 0; i < rows && pageNum < numPages; i++) {
     double rowMax = 0;
@@ -215,11 +216,11 @@ void PrintWidget::layoutPages() {
       double itemWidth = 0, itemHeight = 0;
       double pageHeight = pages.at(pageNum)->boundingRect().height();
 
-      for(int k = cols * (pageNum / cols); k < pageNum; k++)
+      for (int k = cols * (pageNum / cols); k < pageNum; k++)
         itemWidth += pages.at(k)->boundingRect().width();
 
-      foreach(double size, rowMaxList)
-        itemHeight += size;  
+      foreach (double size, rowMaxList)
+        itemHeight += size;
 
       pages.at(pageNum)->setPos(QPointF(itemWidth, itemHeight));
       pageNum++;
@@ -228,46 +229,47 @@ void PrintWidget::layoutPages() {
     rowMaxList.push_back(rowMax);
   }
   scene->setSceneRect(scene->itemsBoundingRect());
-  //qDebug() << "Finished Page Layout";
+  // qDebug() << "Finished Page Layout";
 }
 
-void PrintWidget::populateScene()
-{
-  for (int i = 0; i < pages.size(); i++){
-    scene->removeItem(pages.at(i));
-  }
-  qDeleteAll(pages);
+void PrintWidget::populateScene() {
+  // qDeleteAll(scene->items().begin(), scene->items().end());
+  scene->clear();
+  // qDeleteAll(pages.begin(), pages.end());
   pages.clear();
   links.clear();
   annots.clear();
-  int numPages = BACKEND->numPages();
-  if(BACKEND->hashSize() < numPages){ return; } //nothing to show yet
+  // int numPages = BACKEND->numPages();
+  if (!BACKEND->isDoneLoading()) {
+    qDebug() << "populateScene() called while backend still loading.\n";
+    return;
+  } // nothing to show yet
 
-  for (int i = 0; i < numPages; i++) {
+  for (int i = curPage; i < curPage + 1; i++) {
     QImage pagePicture = BACKEND->imageHash(i);
     QSize paperSize = pagePicture.size();
-    QList<QGraphicsItem*> linkLocations;
-    QList<QGraphicsItem*> annotLocations;
+    QList<QGraphicsItem *> linkLocations;
+    QList<QGraphicsItem *> annotLocations;
 
-    if(pagePicture.isNull()) {
+    if (pagePicture.isNull()) {
       qDebug() << "NULL IMAGE ON PAGE " << i;
       continue;
     }
 
-    PageItem* item = new PageItem(i+1, pagePicture, paperSize, BACKEND);
+    PageItem *item = new PageItem(i + 1, pagePicture, paperSize, BACKEND);
     scene->addItem(item);
     pages.append(item);
 
-    if(BACKEND->supportsExtraFeatures()) {
-      for(int k = 0; k < BACKEND->linkSize(i); k++) {
+    if (BACKEND->supportsExtraFeatures()) {
+      for (int k = 0; k < BACKEND->linkSize(i); k++) {
         LinkItem *lItem = new LinkItem(item, BACKEND->linkList(i, k));
         lItem->setOpacity(0.1);
         linkLocations.append(lItem);
       }
-      //qDebug() << "Creating annotations for:" <<  i;
-      for(int k = 0; k < BACKEND->annotSize(i); k++) {
-        Annotation *annot = BACKEND->annotList(i, k); 
-        if(annot->getType() == 14) {
+      // qDebug() << "Creating annotations for:" <<  i;
+      for (int k = 0; k < BACKEND->annotSize(i); k++) {
+        Annotation *annot = BACKEND->annotList(i, k);
+        if (annot->getType() == 14) {
           InkItem *iItem = new InkItem(item, annot);
           annotLocations.append(iItem);
         }
@@ -278,31 +280,38 @@ void PrintWidget::populateScene()
         annotLocations.append(aZone);
       }
 
-      for(int k = 0; k < BACKEND->widgetSize(i); k++) {
+      for (int k = 0; k < BACKEND->widgetSize(i); k++) {
         Widget *widget = BACKEND->widgetList(i, k);
         int type = widget->getWidgetType();
         QRectF loc = widget->getLocation();
         QString text = widget->getCurrentText();
-        if(type == 0) {
+        switch (type) {
+        case 0: {
           QPushButton *button = new QPushButton(widget->getCurrentText());
           button->setGeometry(loc.toRect());
           button->setText(text);
           QGraphicsProxyWidget *proxy = new QGraphicsProxyWidget(item);
           proxy->setWidget(button);
-        }else if(type == 1) {
+        } break;
+        case 1: {
 
-        }else if(type == 2) {
+        } break;
+        case 2: {
 
-        }else if(type == 3) {
+        } break;
+        case 3: {
 
-        }else if(type == 4) {
+        } break;
+        case 4: {
 
-        }else if(type == 5) {
+        } break;
+        case 5: {
 
-        }else if(type == 6) {
+        } break;
+        case 6: {
 
-        }else {
-          qDebug() << "INVALID WIDGET";
+        } break;
+        default: { qDebug() << "INVALID WIDGET"; }
         }
       }
       links.insert(i, linkLocations);
@@ -311,7 +320,7 @@ void PrintWidget::populateScene()
   }
 }
 
-//Private Slots
+// Private Slots
 void PrintWidget::updateCurrentPage() {
   if (viewMode == AllPagesView)
     return;
@@ -326,12 +335,16 @@ void PrintWidget::updateCurrentPage() {
 
 int PrintWidget::calcCurrentPage() {
   int maxArea = 0;
+
+  return curPage;
+
   int newPage = curPage;
   QRect viewRect = this->viewport()->rect();
-  QList<QGraphicsItem*> items = this->items(viewRect);
-  for (int i=0; i<items.size(); ++i) {
-    PageItem* pg = static_cast<PageItem*>(items.at(i));
-    QRect overlap = this->mapFromScene(pg->sceneBoundingRect()).boundingRect() & viewRect;
+  QList<QGraphicsItem *> items = this->items(viewRect);
+  for (int i = 0; i < items.size(); ++i) {
+    PageItem *pg = static_cast<PageItem *>(items.at(i));
+    QRect overlap =
+        this->mapFromScene(pg->sceneBoundingRect()).boundingRect() & viewRect;
     int area = overlap.width() * overlap.height();
     if (area > maxArea) {
       maxArea = area;
@@ -352,9 +365,10 @@ void PrintWidget::fit(bool doFitting) {
   if (doFitting && fitting) {
     QRect viewRect = this->viewport()->rect();
     if (zoomMode == FitInView) {
-      QList<QGraphicsItem*> containedItems = this->items(viewRect, Qt::ContainsItemBoundingRect);
-      foreach(QGraphicsItem* item, containedItems) {
-        PageItem* pg = static_cast<PageItem*>(item);
+      QList<QGraphicsItem *> containedItems =
+          this->items(viewRect, Qt::ContainsItemBoundingRect);
+      foreach (QGraphicsItem *item, containedItems) {
+        PageItem *pg = static_cast<PageItem *>(item);
         if (pg->pageNumber() == curPage)
           return;
       }
@@ -365,7 +379,7 @@ void PrintWidget::fit(bool doFitting) {
       curPage = newPage;
   }
 
-  QRectF target = pages.at(curPage-1)->sceneBoundingRect();
+  QRectF target = pages.at(curPage - 1)->sceneBoundingRect();
   if (viewMode == FacingPagesView) {
     if (curPage % 2)
       target.setLeft(target.left() - target.width());
@@ -381,7 +395,8 @@ void PrintWidget::fit(bool doFitting) {
     t.scale(scale, scale);
     this->setTransform(t);
     if (doFitting && fitting) {
-      QRectF viewSceneRect = this->viewportTransform().mapRect(this->viewport()->rect());
+      QRectF viewSceneRect =
+          this->viewportTransform().mapRect(this->viewport()->rect());
       viewSceneRect.moveTop(target.top());
       this->ensureVisible(viewSceneRect); // Nah...
     }
@@ -398,29 +413,29 @@ void PrintWidget::fit(bool doFitting) {
 }
 
 void PrintWidget::goToPosition(int pagenum, float x, float y) {
-  //qDebug() << "Page:" << pagenum << "X:" << x << "Y:" << y;
+  // qDebug() << "Page:" << pagenum << "X:" << x << "Y:" << y;
   setCurrentPage(pagenum);
-  
+
   QScrollBar *hsc = this->horizontalScrollBar();
   QScrollBar *vsc = this->verticalScrollBar();
-  QPointF pt = this->transform().map(pages.at(pagenum-1)->pos());
-  int secondPagenum = pagenum < pages.size() ? pagenum : pagenum-2;
+  QPointF pt = this->transform().map(pages.at(pagenum - 1)->pos());
+  int secondPagenum = pagenum < pages.size() ? pagenum : pagenum - 2;
   QPointF pt2 = this->transform().map(pages.at(secondPagenum)->pos());
-  double realHeight = pages.at(pagenum-1)->boundingRect().height();
+  double realHeight = pages.at(pagenum - 1)->boundingRect().height();
   double virtualHeight = qAbs(pt2.y() - pt.y());
 
-  //qDebug() << "Real:" << realHeight << "Virtual:" << virtualHeight;
+  // qDebug() << "Real:" << realHeight << "Virtual:" << virtualHeight;
 
-  int yConv = int(pt.y() + y*(virtualHeight/realHeight)) - 30;
-  int xConv = int(pt.x() + x*(virtualHeight/realHeight)) - 30;
+  int yConv = int(pt.y() + y * (virtualHeight / realHeight)) - 30;
+  int xConv = int(pt.x() + x * (virtualHeight / realHeight)) - 30;
 
-  //qDebug() << "newX:" << xConv << "newY:" << yConv;
+  // qDebug() << "newX:" << xConv << "newY:" << yConv;
 
-  if(yConv > vsc->maximum())
+  if (yConv > vsc->maximum())
     vsc->triggerAction(QAbstractSlider::SliderToMaximum);
-  else if(y != 0)
+  else if (y != 0)
     vsc->setValue(yConv);
 
-  if(x != 0)
+  if (x != 0)
     hsc->setValue(xConv);
 }

--- a/src-qt5/desktop-utils/lumina-pdf/PrintWidget.h
+++ b/src-qt5/desktop-utils/lumina-pdf/PrintWidget.h
@@ -10,208 +10,27 @@
 #ifndef _PRINT_GRAPHICS_H
 #define _PRINT_GRAPHICS_H
 
-#include <QMouseEvent>
-#include <QDebug>
-#include <QGraphicsView>
-#include <QGraphicsItem>
-#include <QBoxLayout>
-#include <QScrollBar>
-#include <QStyleOptionGraphicsItem>
-#include <QtMath>
-#include <QPageLayout>
-#include <QTextDocument>
-#include <QApplication>
 #include "Renderer.h"
 #include "TextData.h"
+#include "graphicsitems.h"
+#include <QApplication>
+#include <QBoxLayout>
+#include <QDebug>
+#include <QGraphicsItem>
+#include <QGraphicsView>
+#include <QMouseEvent>
+#include <QPageLayout>
+#include <QScrollBar>
+#include <QStyleOptionGraphicsItem>
+#include <QTextDocument>
+#include <QtMath>
 
-class InkItem: public QGraphicsItem {
-public:
-  InkItem(QGraphicsItem *parent, Annotation *_annot) : QGraphicsItem(parent), pointData(_annot->getInkList()), inkColor(_annot->getColor()), annot(_annot) {
-    setCacheMode(DeviceCoordinateCache);
-    bbox = annot->getLoc();
-  }
-
-  QRectF boundingRect() const Q_DECL_OVERRIDE { return bbox; }
-
-  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE
-  {
-    Q_UNUSED(widget);
-    painter->setClipRect(option->exposedRect);
-    QPen inkPen = QPen(inkColor);
-    painter->setPen(inkPen);
-    foreach(QVector<QPointF> pointList, pointData) {
-      painter->drawLines(pointList);
-    }
-  }
-
-private:
-  QRectF bbox;
-  QVector<QVector<QPointF>> pointData;
-  QColor inkColor;
-  Annotation *annot;
-};
-
-class PopupItem: public QGraphicsItem {
-public:
-  PopupItem(QGraphicsItem *parent, Annotation *_annot) : QGraphicsItem(parent), author(_annot->getAuthor()), text(_annot->getText()) {
-    QRectF loc = _annot->getLoc();
-    setCacheMode(DeviceCoordinateCache);
-    QString allText = "Author: " + author + "\n\n" + text;
-    QTextDocument document;
-    document.setDefaultFont(QFont("Helvitica", 10, QFont::Normal));
-    document.setPageSize(QSize(120, 120));
-    document.setHtml(allText);
-    loc.moveTopLeft(QPointF(loc.center().x(), loc.center().y()+loc.height()/2));
-    loc.setSize(document.size()+QSize(10, 10));
-    bbox = loc;
-  }
-
-  QRectF boundingRect() const Q_DECL_OVERRIDE { return bbox; }
-
-  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE
-  {
-    Q_UNUSED(widget);
-    QString allText = "Author: " + author + "\n\n" + text;
-    painter->setClipRect(option->exposedRect);
-    painter->setFont(QFont("Helvitica", 10, QFont::Normal));
-    painter->setBrush(QBrush(QColor(255, 255, 177, 255)));
-    painter->drawRect(bbox);
-    painter->setPen(QPen(QColor("Black")));
-    painter->drawText(bbox, Qt::AlignLeft | Qt::TextWordWrap, allText);
-  }
-
-private:
-  QRectF bbox;
-  QString author;
-  QString text;
-};
-
-class AnnotZone: public QGraphicsItem {
-public:
-  AnnotZone(QGraphicsItem *parent, Annotation *_annot, PopupItem *_annotItem) : QGraphicsItem(parent), bbox(_annot->getLoc()), annot(_annotItem) { 
-    _hasText = !_annot->getText().isEmpty(); 
-    _hasAuthor = !_annot->getAuthor().isEmpty(); 
-  }
-
-  QRectF boundingRect() const Q_DECL_OVERRIDE { return bbox; }
-  PopupItem* annotation() const { return annot; }
-  bool hasText() const { return _hasText; }
-  bool hasAuthor() const { return _hasAuthor; }
-  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE { Q_UNUSED(widget); Q_UNUSED(painter); Q_UNUSED(option); } 
-
-private:
-  QRectF bbox;
-  PopupItem *annot;
-  bool _hasText;
-  bool _hasAuthor;
-};
-
-class LinkItem: public QGraphicsItem {
-public:
-  LinkItem(QGraphicsItem *parent, TextData *_data) : QGraphicsItem(parent), bbox(_data->loc()), data(_data) {
-    setCacheMode(DeviceCoordinateCache);
-    setAcceptHoverEvents(true);
-  }
-
-QRectF boundingRect() const Q_DECL_OVERRIDE
-  { return bbox; }
-
-inline TextData* getData() const
-  { return data; }
-
-void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE
-{
-  Q_UNUSED(widget);
-  painter->setClipRect(option->exposedRect);
-  painter->setBrush(QBrush(QColor(255, 255, 177, 100)));
-  painter->setPen(QPen(QColor(255, 255, 100, 125)));
-  painter->drawRect(bbox);
-}
-
-private:
-  QRectF bbox;
-  TextData *data;
-};
-
-class PageItem : public QGraphicsItem {
-public:
-  PageItem(int _pageNum, QImage _pagePicture, QSize _paperSize, Renderer *_backend)
-        : pageNum(_pageNum), pagePicture(_pagePicture), paperSize(_paperSize), BACKEND(_backend)
-  {
-    brect = QRectF(QPointF(-25, -25),
-              QSizeF(paperSize)+QSizeF(50, 50));
-    setCacheMode(DeviceCoordinateCache);
-    setAcceptHoverEvents(true);
-  }
-
-  QRectF boundingRect() const Q_DECL_OVERRIDE
-    { return brect; }
-
-  inline int pageNumber() const
-    { return pageNum; }
-
-  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE
-  {
-    Q_UNUSED(widget);
-    //Ensure all the antialiasing/smoothing options are turned on
-    painter->setRenderHint(QPainter::Antialiasing);
-    painter->setRenderHint(QPainter::TextAntialiasing);
-    painter->setRenderHint(QPainter::SmoothPixmapTransform);
-
-    QRectF paperRect(0,0, paperSize.width(), paperSize.height());
-    // Draw shadow
-    painter->setClipRect(option->exposedRect);
-    qreal shWidth = paperRect.width()/100;
-    QRectF rshadow(paperRect.topRight() + QPointF(0, shWidth),
-           paperRect.bottomRight() + QPointF(shWidth, 0));
-    QLinearGradient rgrad(rshadow.topLeft(), rshadow.topRight());
-    rgrad.setColorAt(0.0, QColor(0,0,0,255));
-    rgrad.setColorAt(1.0, QColor(0,0,0,0));
-    painter->fillRect(rshadow, QBrush(rgrad));
-    QRectF bshadow(paperRect.bottomLeft() + QPointF(shWidth, 0),
-           paperRect.bottomRight() + QPointF(0, shWidth));
-    QLinearGradient bgrad(bshadow.topLeft(), bshadow.bottomLeft());
-    bgrad.setColorAt(0.0, QColor(0,0,0,255));
-    bgrad.setColorAt(1.0, QColor(0,0,0,0));
-    painter->fillRect(bshadow, QBrush(bgrad));
-    QRectF cshadow(paperRect.bottomRight(),
-           paperRect.bottomRight() + QPointF(shWidth, shWidth));
-    QRadialGradient cgrad(cshadow.topLeft(), shWidth, cshadow.topLeft());
-    cgrad.setColorAt(0.0, QColor(0,0,0,255));
-    cgrad.setColorAt(1.0, QColor(0,0,0,0));
-    painter->fillRect(cshadow, QBrush(cgrad));
-    painter->setClipRect(paperRect & option->exposedRect);
-    painter->fillRect(paperRect, Qt::white);
-    painter->drawImage(QPoint(0,0), pagePicture);
-    for(int k = 0; k < BACKEND->annotSize(pageNum-1); k++) {
-      Annotation *annot = BACKEND->annotList(pageNum-1, k);
-      painter->drawImage(annot->getLoc(), annot->renderImage());
-    }
-  }
-
-private:
-  int pageNum;
-  QImage pagePicture;
-  QSize paperSize;
-  QRectF brect;
-  Renderer *BACKEND;
-};
-
-class PrintWidget : public QGraphicsView
-{
+class PrintWidget : public QGraphicsView {
   Q_OBJECT
 public:
-  enum ViewMode {
-    SinglePageView,
-    FacingPagesView,
-    AllPagesView
-  };
+  enum ViewMode { SinglePageView, FacingPagesView, AllPagesView };
 
-  enum ZoomMode {
-    CustomZoom,
-    FitToWidth,
-    FitInView
-  };
+  enum ZoomMode { CustomZoom, FitToWidth, FitInView };
 
 private:
   void generatePreview();
@@ -227,9 +46,9 @@ private:
   QPageLayout::Orientation orientation;
   double zoomFactor;
   bool initialized, fitting;
-  QList<QGraphicsItem*> pages;
-  QHash<int, QList<QGraphicsItem*>> links;
-  QHash<int, QList<QGraphicsItem*>> annots;
+  QList<QGraphicsItem *> pages;
+  QHash<int, QList<QGraphicsItem *>> links;
+  QHash<int, QList<QGraphicsItem *>> annots;
   int degrees;
   Renderer *BACKEND;
 
@@ -237,21 +56,24 @@ public:
   PrintWidget(Renderer *backend, QWidget *parent = 0);
   ~PrintWidget();
 
-  double getZoomFactor() const { return this->zoomFactor; };
-  ZoomMode getZoomMode() const { return this->zoomMode; };
-  int currentPage() const { return publicPageNum; };
+  double getZoomFactor() const { return this->zoomFactor; }
+  ZoomMode getZoomMode() const { return this->zoomMode; }
+  int currentPage() const {
+    return curPage;
+    return publicPageNum;
+  }
 
 signals:
   void resized();
-  void customContextMenuRequested(const QPoint&);
+  void customContextMenuRequested(const QPoint &);
   void currentPageChanged();
 
 public slots:
-  void zoomIn(double factor=1.2);
-  void zoomOut(double factor=1.2);
+  void zoomIn(double factor = 1.2);
+  void zoomOut(double factor = 1.2);
   void setCurrentPage(int);
   void setVisible(bool) Q_DECL_OVERRIDE;
-  void highlightText(TextData*);
+  void highlightText(TextData *);
   void goToPosition(int, float, float);
 
   void updatePreview();
@@ -264,25 +86,25 @@ public slots:
 private slots:
   void updateCurrentPage();
   int calcCurrentPage();
-  void fit(bool doFitting=false);
+  void fit(bool doFitting = false);
 
 protected:
-  void resizeEvent(QResizeEvent* e) Q_DECL_OVERRIDE {
+  void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE {
     /*{
-      const QSignalBlocker blocker(verticalScrollBar()); // Don't change page, QTBUG-14517
-      QGraphicsView::resizeEvent(e);
+      const QSignalBlocker blocker(verticalScrollBar()); // Don't change page,
+    QTBUG-14517 QGraphicsView::resizeEvent(e);
     }*/
     QGraphicsView::resizeEvent(e);
     emit resized();
-   }
+  }
 
-  void clearItems(QList<QGraphicsItem*> itemList, QGraphicsItem *item) {
-    foreach(QGraphicsItem *graphicsItem, itemList) {
-      if(item == graphicsItem)
+  void clearItems(QList<QGraphicsItem *> itemList, QGraphicsItem *item) {
+    foreach (QGraphicsItem *graphicsItem, itemList) {
+      if (item == graphicsItem)
         continue;
-      if(graphicsItem == dynamic_cast<LinkItem*>(graphicsItem))
+      if (graphicsItem == dynamic_cast<LinkItem *>(graphicsItem))
         graphicsItem->setOpacity(0.1);
-      if(graphicsItem == dynamic_cast<PopupItem*>(graphicsItem))
+      if (graphicsItem == dynamic_cast<PopupItem *>(graphicsItem))
         graphicsItem->setVisible(false);
     }
   }
@@ -291,28 +113,29 @@ protected:
     QGraphicsView::mouseMoveEvent(e);
     static bool cursorSet = false;
 
-    if(QGraphicsItem *item = scene->itemAt(mapToScene(e->pos()), transform())) {
-      QList<QGraphicsItem*> linkList;
-      if(item == dynamic_cast<PopupItem*>(item))
+    if (QGraphicsItem *item =
+            scene->itemAt(mapToScene(e->pos()), transform())) {
+      QList<QGraphicsItem *> linkList;
+      if (item == dynamic_cast<PopupItem *>(item))
         item = item->parentItem();
 
-      if(PageItem *page = dynamic_cast<PageItem*>(item))
+      if (PageItem *page = dynamic_cast<PageItem *>(item))
         linkList = page->childItems();
-      else if(item != dynamic_cast<QGraphicsRectItem*>(item))
+      else if (item != dynamic_cast<QGraphicsRectItem *>(item))
         linkList = item->parentItem()->childItems();
 
-      if(LinkItem *link = dynamic_cast<LinkItem*>(item)){
+      if (LinkItem *link = dynamic_cast<LinkItem *>(item)) {
         item->setOpacity(1);
-        if(!cursorSet) {
+        if (!cursorSet) {
           QApplication::setOverrideCursor(QCursor(Qt::PointingHandCursor));
           cursorSet = true;
         }
-      }else if(cursorSet){
+      } else if (cursorSet) {
         QApplication::restoreOverrideCursor();
         cursorSet = false;
       }
-      if(AnnotZone *annotZone = dynamic_cast<AnnotZone*>(item)){
-        if(annotZone->hasText() or annotZone->hasAuthor())
+      if (AnnotZone *annotZone = dynamic_cast<AnnotZone *>(item)) {
+        if (annotZone->hasText() or annotZone->hasAuthor())
           annotZone->annotation()->setVisible(true);
         item = annotZone->annotation();
       }
@@ -324,13 +147,13 @@ protected:
     QGraphicsView::mouseReleaseEvent(e);
     QPointF scenePoint = mapToScene(e->pos());
     QGraphicsItem *item = scene->itemAt(scenePoint, transform());
-    if(LinkItem *link = dynamic_cast<LinkItem*>(item)) {
+    if (LinkItem *link = dynamic_cast<LinkItem *>(item)) {
       BACKEND->handleLink(this, link->getData()->text());
       link->setOpacity(0.1);
     }
   }
 
-  void showEvent(QShowEvent* e) Q_DECL_OVERRIDE {
+  void showEvent(QShowEvent *e) Q_DECL_OVERRIDE {
     QGraphicsView::showEvent(e);
     emit resized();
   }

--- a/src-qt5/desktop-utils/lumina-pdf/PropDialog.cpp
+++ b/src-qt5/desktop-utils/lumina-pdf/PropDialog.cpp
@@ -9,14 +9,15 @@
 #include "ui_PropDialog.h"
 #include <LuminaXDG.h>
 
-PropDialog::PropDialog(Renderer *Backend) : QDialog(), ui(new Ui::PropDialog()), BACKEND(Backend){
+PropDialog::PropDialog(Renderer *Backend)
+    : QDialog(), ui(new Ui::PropDialog()), BACKEND(Backend) {
   ui->setupUi(this);
   this->setWindowTitle(tr("PDF Information"));
-  this->setWindowIcon( LXDG::findIcon("dialog-information","unknown"));
+  this->setWindowIcon(LXDG::findIcon("dialog-information", "unknown"));
 
-  connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(close()));
+  QObject::connect(ui->closeButton, SIGNAL(clicked()), this, SLOT(close()));
 
-  //Setup translations
+  // Setup translations
   ui->titleL->setText(tr("Title:"));
   ui->subjectL->setText(tr("Subject:"));
   ui->authorL->setText(tr("Author:"));
@@ -29,21 +30,23 @@ PropDialog::PropDialog(Renderer *Backend) : QDialog(), ui(new Ui::PropDialog()),
   ui->closeButton->setText(tr("Close"));
 }
 
-//Load size from mainUI after pages have loaded
+// Load size from mainUI after pages have loaded
 void PropDialog::setSize(QSizeF pageSize) {
-  ui->sizeL->setText(tr("Page Size: ") + QString::number(pageSize.width())+", "+QString::number(pageSize.height()));
+  ui->sizeL->setText(tr("Page Size: ") + QString::number(pageSize.width()) +
+                     ", " + QString::number(pageSize.height()));
 }
 
-//Fill the text boxes with information from the document
+// Fill the text boxes with information from the document
 void PropDialog::setInformation() {
   QJsonObject info = BACKEND->properties();
-  ui->titleE->setText( info.value("title").toString() );
-  ui->subjectE->setText( info.value("subject").toString() );
-  ui->authorE->setText( info.value("author").toString() );
-  ui->creatorE->setText( info.value("creator").toString() );
-  ui->producerE->setText( info.value("producer").toString() );
-  ui->keywordE->setText( info.value("keywords").toString() );
-  ui->createdEntry->setText( info.value("dt_created").toString() );
-  ui->modifiedEntry->setText( info.value("dt_modified").toString() );
-  ui->numberL->setText( tr("Number of Pages: ") + QString::number(BACKEND->numPages()) );
+  ui->titleE->setText(info.value("title").toString());
+  ui->subjectE->setText(info.value("subject").toString());
+  ui->authorE->setText(info.value("author").toString());
+  ui->creatorE->setText(info.value("creator").toString());
+  ui->producerE->setText(info.value("producer").toString());
+  ui->keywordE->setText(info.value("keywords").toString());
+  ui->createdEntry->setText(info.value("dt_created").toString());
+  ui->modifiedEntry->setText(info.value("dt_modified").toString());
+  ui->numberL->setText(tr("Number of Pages: ") +
+                       QString::number(BACKEND->numPages()));
 }

--- a/src-qt5/desktop-utils/lumina-pdf/PropDialog.h
+++ b/src-qt5/desktop-utils/lumina-pdf/PropDialog.h
@@ -6,24 +6,24 @@
 //===========================================
 #pragma once
 
+#include "Renderer.h"
 #include <QDialog>
 #include <QTextEdit>
-#include "Renderer.h"
 
-namespace Ui{
-  class PropDialog;
+namespace Ui {
+class PropDialog;
 };
 
 class PropDialog : public QDialog {
   Q_OBJECT
-  public:
-    PropDialog(Renderer *Backend);
+public:
+  PropDialog(Renderer *Backend);
 
-  public slots:
-    void setSize(QSizeF);
-    void setInformation();
+public slots:
+  void setSize(QSizeF);
+  void setInformation();
 
-  private:
-    Ui::PropDialog *ui;
-    Renderer *BACKEND;
+private:
+  Ui::PropDialog *ui;
+  Renderer *BACKEND;
 };

--- a/src-qt5/desktop-utils/lumina-pdf/Renderer-mupdf.cpp
+++ b/src-qt5/desktop-utils/lumina-pdf/Renderer-mupdf.cpp
@@ -1,159 +1,175 @@
-#include "Renderer.h" 
-#include "TextData.h" 
+#include "Renderer.h"
+#include "TextData.h"
+#include <QDateTime>
+#include <QFuture>
+#include <QMutex>
+#include <QtConcurrent>
 #include <mupdf/fitz.h>
 #include <mupdf/pdf.h>
-#include <QDateTime>
-#include <QMutex>
-#include <QFuture>
-#include <QtConcurrent>
 
 class Annot;
 
-inline QRectF convertRect(fz_rect bbox, double sf=1.0) {
-  return QRectF(sf*bbox.x0, sf*bbox.y0, sf*(bbox.x1-bbox.x0), sf*(bbox.y1 - bbox.y0));
+inline QRectF convertRect(fz_rect bbox, double sf = 1.0) {
+  return QRectF(sf * bbox.x0, sf * bbox.y0, sf * (bbox.x1 - bbox.x0),
+                sf * (bbox.y1 - bbox.y0));
 }
 
 class Link {
-  public:
-    Link(fz_context *_ctx, fz_link *_fzLink, char *_uri, int _page, QRectF _loc = QRectF()) : fzLink(_fzLink), ctx(_ctx) {
-      QString uri = QString::fromLocal8Bit(_uri); 
-      data = new TextData(_loc, _page, uri);
-    }
+public:
+  Link(fz_context *_ctx, fz_link *_fzLink, char *_uri, int _page,
+       QRectF _loc = QRectF())
+      : fzLink(_fzLink), ctx(_ctx) {
+    QString uri = QString::fromLocal8Bit(_uri);
+    data = new TextData(_loc, _page, uri);
+  }
 
-    ~Link() {
-      fz_drop_link(ctx, fzLink);
-      delete data;
-    }
+  ~Link() {
+    fz_drop_link(ctx, fzLink);
+    delete data;
+  }
 
-    TextData* getData() { return data; }
+  TextData *getData() { return data; }
 
-  private:
-    TextData *data;
-    fz_link *fzLink;
-    fz_context *ctx;
+private:
+  TextData *data;
+  fz_link *fzLink;
+  fz_context *ctx;
 };
 
 class Data {
-  public:
-    Data(int _pagenum, fz_context *_ctx, fz_display_list *_list, fz_rect _bbox, fz_matrix _ctm, double _sf, fz_link *_link, QList<Annot*> &_annot, QList<Widget*> &_widgets) : pagenumber(_pagenum), ctx(_ctx), list(_list), bbox(_bbox), ctm(_ctm), sf(_sf), annotList(_annot), widgetList(_widgets) {
+public:
+  Data(int _pagenum, fz_context *_ctx, fz_display_list *_list, fz_rect _bbox,
+       fz_matrix _ctm, double _sf, fz_link *_link, QList<Annot *> &_annot,
+       QList<Widget *> &_widgets)
+      : pagenumber(_pagenum), ctx(_ctx), list(_list), bbox(_bbox), ctm(_ctm),
+        sf(_sf), annotList(_annot), widgetList(_widgets) {
 
-      while(_link) {
-        QRectF rect = convertRect(_link->rect, sf);
-        Link *link = new Link(_ctx, _link, _link->uri, _pagenum, rect);
-        linkList.append(link);
-        _link = _link->next;
-      }
+    while (_link) {
+      QRectF rect = convertRect(_link->rect, sf);
+      Link *link = new Link(_ctx, _link, _link->uri, _pagenum, rect);
+      linkList.append(link);
+      _link = _link->next;
     }
+  }
 
-    ~Data() { 
-      fz_drop_pixmap(ctx, pix);
-      fz_drop_display_list(ctx, list);
-      qDeleteAll(linkList);
-      linkList.clear();
-      qDeleteAll(annotList);
-      annotList.clear();
-      qDeleteAll(widgetList);
-      widgetList.clear();
-    }
+  ~Data() {
+    fz_drop_pixmap(ctx, pix);
+    fz_drop_display_list(ctx, list);
+    qDeleteAll(linkList);
+    linkList.clear();
+    qDeleteAll(annotList);
+    annotList.clear();
+    qDeleteAll(widgetList);
+    widgetList.clear();
+  }
 
-    int getPage() { return pagenumber; }
-    QList<Link*> getLinkList() { return linkList; }
-    Annot* getAnnotList(int i) { return annotList[i]; }
-    Widget* getWidgetList(int i) { return widgetList[i]; }
-    int getAnnotSize() { return annotList.size(); }
-    int getWidgetSize() { return widgetList.size(); }
-    fz_context* getContext() { return ctx; }
-    fz_display_list* getDisplayList() { return list; }
-    QRectF getScaledRect() { return convertRect(bbox, sf); }
-    QRectF getScaledRect(fz_rect &rect) { return convertRect(rect, sf); }
-    fz_rect getBoundingBox() { return bbox; }
-    fz_matrix getMatrix() { return ctm; }
-    QImage getImage() { return img; }
+  int getPage() { return pagenumber; }
+  QList<Link *> getLinkList() { return linkList; }
+  Annot *getAnnotList(int i) { return annotList[i]; }
+  Widget *getWidgetList(int i) { return widgetList[i]; }
+  int getAnnotSize() { return annotList.size(); }
+  int getWidgetSize() { return widgetList.size(); }
+  fz_context *getContext() { return ctx; }
+  fz_display_list *getDisplayList() { return list; }
+  QRectF getScaledRect() { return convertRect(bbox, sf); }
+  QRectF getScaledRect(fz_rect &rect) { return convertRect(rect, sf); }
+  fz_rect getBoundingBox() { return bbox; }
+  fz_matrix getMatrix() { return ctm; }
+  QImage getImage() { return img; }
 
-    void setImage(QImage _img) { img = _img; }
-    void setRenderThread(QFuture<void> thread) { renderThread = thread; }
-    void setPixmap(fz_pixmap *_pix) { pix = _pix; }
-    
-  private:
-    int pagenumber;
-    fz_context *ctx;
-    fz_display_list *list;
-    fz_rect bbox;
-    fz_matrix ctm;
-    QList<Link*> linkList;
-    double sf;
-    QList<Annot*> annotList;
-    QList<Widget*> widgetList;
+  void setImage(QImage _img) { img = _img; }
+  void setRenderThread(QFuture<void> thread) { renderThread = thread; }
+  void setPixmap(fz_pixmap *_pix) { pix = _pix; }
 
-    fz_pixmap *pix;
-    QImage img;
-    QFuture<void> renderThread;
+private:
+  int pagenumber;
+  fz_context *ctx;
+  fz_display_list *list;
+  fz_rect bbox;
+  fz_matrix ctm;
+  QList<Link *> linkList;
+  double sf;
+  QList<Annot *> annotList;
+  QList<Widget *> widgetList;
+
+  fz_pixmap *pix;
+  QImage img;
+  QFuture<void> renderThread;
 };
 
 fz_document *DOC;
 fz_context *CTX;
-QHash<int, Data*> dataHash;
+QHash<int, Data *> dataHash;
 QMutex mutex[FZ_LOCK_MAX];
 fz_locks_context locks;
 
-class Annot : public Annotation{
-  public:
-    Annot(fz_context *_ctx, pdf_annot *_fzAnnot, int _type, int _i, float _opacity, QRectF _loc = QRectF()) : Annotation(_type, _opacity, _loc), ctx(_ctx), fzAnnot(_fzAnnot), pageNum(_i) { }
-    virtual ~Annot() { fz_drop_annot(ctx, (fz_annot*)fzAnnot); }
+class Annot : public Annotation {
+public:
+  Annot(fz_context *_ctx, pdf_annot *_fzAnnot, int _type, int _i,
+        float _opacity, QRectF _loc = QRectF())
+      : Annotation(_type, _opacity, _loc), ctx(_ctx), fzAnnot(_fzAnnot),
+        pageNum(_i) {}
+  virtual ~Annot() { fz_drop_annot(ctx, (fz_annot *)fzAnnot); }
 
-    virtual QImage renderImage() {
-      fz_rect bbox;
-      fz_irect rbox;
-      pdf_bound_annot(ctx, fzAnnot, &bbox);
+  virtual QImage renderImage() {
+    fz_rect bbox;
+    fz_irect rbox;
+    pdf_bound_annot(ctx, fzAnnot, &bbox);
 
-      fz_pixmap *pixmap = fz_new_pixmap_with_bbox(ctx, fz_device_rgb(ctx), fz_round_rect(&rbox, &bbox), NULL, 0);
-      fz_clear_pixmap_with_value(ctx, pixmap, 0xff);
-      fz_device *dev = fz_new_draw_device(ctx, &fz_identity, pixmap);
-      fz_run_display_list(ctx, dataHash[pageNum]->getDisplayList(), dev, &fz_identity, &bbox, NULL);
+    fz_pixmap *pixmap = fz_new_pixmap_with_bbox(
+        ctx, fz_device_rgb(ctx), fz_round_rect(&rbox, &bbox), NULL, 0);
+    fz_clear_pixmap_with_value(ctx, pixmap, 0xff);
+    fz_device *dev = fz_new_draw_device(ctx, &fz_identity, pixmap);
+    fz_run_display_list(ctx, dataHash[pageNum]->getDisplayList(), dev,
+                        &fz_identity, &bbox, NULL);
 
-      QImage image(pixmap->samples, pixmap->w, pixmap->h, pixmap->stride, QImage::Format_RGB888);
-      return image;
-    }
-    
-  private:
-    fz_context *ctx;
-    pdf_annot *fzAnnot;
+    QImage image(pixmap->samples, pixmap->w, pixmap->h, pixmap->stride,
+                 QImage::Format_RGB888);
+    return image;
+  }
 
-    int pageNum;
+private:
+  fz_context *ctx;
+  pdf_annot *fzAnnot;
+
+  int pageNum;
 };
 
 inline QString getTextInfo(QString str) {
   char infoBuff[1000];
-  int size = DOC->lookup_metadata(CTX, DOC, ("info:"+str).toLocal8Bit().data(), infoBuff, 1000);
-  if(size != -1){ return QString::fromLatin1(infoBuff); }
+  int size = DOC->lookup_metadata(
+      CTX, DOC, ("info:" + str).toLocal8Bit().data(), infoBuff, 1000);
+  if (size != -1) {
+    return QString::fromLatin1(infoBuff);
+  }
   return "";
 }
 
 void lock_mutex(void *user, int lock) {
-  QMutex *mutex = (QMutex*) user;
+  QMutex *mutex = (QMutex *)user;
   mutex[lock].lock();
 }
 
 void unlock_mutex(void *user, int lock) {
-  QMutex *mutex = (QMutex*) user;
+  QMutex *mutex = (QMutex *)user;
   mutex[lock].unlock();
 }
 
-Renderer::Renderer(){
+Renderer::Renderer() {
   locks.user = mutex;
   locks.lock = lock_mutex;
   locks.unlock = unlock_mutex;
 
   DOC = 0;
-  //qDebug() << "Creating Context";
+  // qDebug() << "Creating Context";
   CTX = fz_new_context(NULL, &locks, FZ_STORE_UNLIMITED);
   needpass = false;
   degrees = 0;
 }
 
-Renderer::~Renderer(){
-  //pdf_clean_page_contents
-  //qDebug() << "Dropping Context";
+Renderer::~Renderer() {
+  // pdf_clean_page_contents
+  // qDebug() << "Dropping Context";
   clearHash();
   fz_drop_document(CTX, DOC);
   DOC = NULL;
@@ -161,7 +177,7 @@ Renderer::~Renderer(){
   CTX = NULL;
 }
 
-bool Renderer::loadMultiThread(){ return false; }
+bool Renderer::loadMultiThread() { return false; }
 
 void Renderer::handleLink(QWidget *obj, QString link) {
   float xp = 0.0, yp = 0.0;
@@ -170,94 +186,109 @@ void Renderer::handleLink(QWidget *obj, QString link) {
   QByteArray linkData = link.toLocal8Bit();
   char *uri = linkData.data();
 
-  if(!link.isEmpty()) {
-    if(fz_is_external_link(CTX, uri)) {
-      if(QMessageBox::Yes == QMessageBox::question(obj, tr("Open External Link?"), QString(tr("Do you want to open %1 in the default browser")).arg(link), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) ){ QProcess::startDetached("firefox \""+link+"\""); }
-    }else{
+  if (!link.isEmpty()) {
+    if (fz_is_external_link(CTX, uri)) {
+      if (QMessageBox::Yes ==
+          QMessageBox::question(
+              obj, tr("Open External Link?"),
+              QString(tr("Do you want to open %1 in the default browser"))
+                  .arg(link),
+              QMessageBox::Yes | QMessageBox::No, QMessageBox::No)) {
+        QProcess::startDetached("firefox \"" + link + "\"");
+      }
+    } else {
       pagenum = fz_resolve_link(CTX, DOC, uri, &xp, &yp);
-      if(pagenum != -1)
-        emit goToPosition(pagenum+1, xp, yp);
+      if (pagenum != -1)
+        emit goToPosition(pagenum + 1, xp, yp);
     }
   }
 }
 
-//Traverse the outline tree through Preorder traversal
+// Traverse the outline tree through Preorder traversal
 void Renderer::traverseOutline(void *link, int level) {
-  fz_outline *olink = (fz_outline*)link;
+  fz_outline *olink = (fz_outline *)link;
 
   Bookmark *bm = new Bookmark(olink->title, olink->uri, olink->page, level);
   bookmarks.push_back(bm);
 
-  if(olink->down)
-    traverseOutline(olink->down, level+1);
-  
-  if(olink->next)
-    traverseOutline(olink->next, level); 
+  if (olink->down)
+    traverseOutline(olink->down, level + 1);
+
+  if (olink->next)
+    traverseOutline(olink->next, level);
 }
 
-bool Renderer::loadDocument(QString path, QString password){
-  //first time through
-  if(path != docpath) {
-    if(DOC != 0) {
+bool Renderer::loadDocument(QString path, QString password) {
+  // first time through
+  if (path != docpath) {
+    if (DOC != 0) {
       qDebug() << "New document";
       fz_drop_document(CTX, DOC);
       DOC = NULL;
       needpass = false;
       docpath = path;
-      if(bookmarks.size() > 0) {
+      if (bookmarks.size() > 0) {
         qDeleteAll(bookmarks);
         bookmarks.clear();
       }
-    }else if(DOC==0){ 
-      fz_register_document_handlers(CTX); 
+    } else if (DOC == 0) {
+      fz_register_document_handlers(CTX);
       qDebug() << "Document handlers registered";
     }
 
-    //fz_page_presentation
+    // fz_page_presentation
 
     docpath = path;
     DOC = fz_open_document(CTX, path.toLocal8Bit().data());
-    //qDebug() << "File opened" << DOC;
-    if(DOC==0){
+    // qDebug() << "File opened" << DOC;
+    if (DOC == 0) {
       qDebug() << "Could not open file:" << path;
       return false;
     }
     needpass = (fz_needs_password(CTX, DOC) != 0);
 
-    if(needpass && password.isEmpty()){ 
-      return false; 
-    }else if(needpass){
+    if (needpass && password.isEmpty()) {
+      return false;
+    } else if (needpass) {
       needpass = !fz_authenticate_password(CTX, DOC, password.toLocal8Bit());
-      if(needpass){ return false; } //incorrect password
+      if (needpass) {
+        return false;
+      } // incorrect password
     }
 
-    //qDebug() << "Password Check cleared";
+    // qDebug() << "Password Check cleared";
     pnum = fz_count_pages(CTX, DOC);
     qDebug() << "Page count: " << pnum;
 
     doctitle.clear();
 
-    //qDebug() << "Opening File:" << path;
-    jobj.insert("subject", getTextInfo("Subject") );
-    jobj.insert("author", getTextInfo("Author") );
-    jobj.insert("creator", getTextInfo("Creator") );
-    jobj.insert("producer", getTextInfo("Producer") );
-    jobj.insert("keywords", getTextInfo("Keywords") );
-    jobj.insert("dt_created", QDateTime::fromString( getTextInfo("CreationDate").left(16), "'D:'yyyyMMddHHmmss").toString() );
-    jobj.insert("dt_modified", QDateTime::fromString( getTextInfo("ModDate").left(16), "'D:'yyyyMMddHHmmss").toString() );
+    // qDebug() << "Opening File:" << path;
+    jobj.insert("subject", getTextInfo("Subject"));
+    jobj.insert("author", getTextInfo("Author"));
+    jobj.insert("creator", getTextInfo("Creator"));
+    jobj.insert("producer", getTextInfo("Producer"));
+    jobj.insert("keywords", getTextInfo("Keywords"));
+    jobj.insert("dt_created",
+                QDateTime::fromString(getTextInfo("CreationDate").left(16),
+                                      "'D:'yyyyMMddHHmmss")
+                    .toString());
+    jobj.insert("dt_modified",
+                QDateTime::fromString(getTextInfo("ModDate").left(16),
+                                      "'D:'yyyyMMddHHmmss")
+                    .toString());
 
-    if(!jobj["title"].toString().isEmpty())
+    if (!jobj["title"].toString().isEmpty())
       doctitle = jobj["title"].toString();
     else
-      doctitle = path.section("/",-1);
+      doctitle = path.section("/", -1);
 
-    //Possibly check Page orientation
+    // Possibly check Page orientation
 
     fz_outline *outline = fz_load_outline(CTX, DOC);
-    if(outline) 
+    if (outline)
       traverseOutline(outline, 0);
-    //else
-      //qDebug() << "No Bookmarks";
+    // else
+    // qDebug() << "No Bookmarks";
 
     fz_drop_outline(CTX, outline);
 
@@ -266,10 +297,9 @@ bool Renderer::loadDocument(QString path, QString password){
   return false;
 }
 
-void renderer(Data *data, Renderer *obj)
-{
+void renderer(Data *data, Renderer *obj) {
   int pagenum = data->getPage();
-  //qDebug() << "Rendering:" << pagenum;
+  // qDebug() << "Rendering:" << pagenum;
   fz_context *ctx = data->getContext();
   fz_rect bbox = data->getBoundingBox();
   fz_matrix ctm = data->getMatrix();
@@ -277,13 +307,15 @@ void renderer(Data *data, Renderer *obj)
   fz_irect rbox;
 
   ctx = fz_clone_context(ctx);
-  fz_pixmap *pixmap = fz_new_pixmap_with_bbox(ctx, fz_device_rgb(ctx), fz_round_rect(&rbox, &bbox), NULL, 0);
+  fz_pixmap *pixmap = fz_new_pixmap_with_bbox(
+      ctx, fz_device_rgb(ctx), fz_round_rect(&rbox, &bbox), NULL, 0);
   fz_clear_pixmap_with_value(ctx, pixmap, 0xff);
 
   dev = fz_new_draw_device(ctx, &fz_identity, pixmap);
   fz_run_display_list(ctx, data->getDisplayList(), dev, &ctm, &bbox, NULL);
 
-  data->setImage(QImage(pixmap->samples, pixmap->w, pixmap->h, pixmap->stride, QImage::Format_RGB888));
+  data->setImage(QImage(pixmap->samples, pixmap->w, pixmap->h, pixmap->stride,
+                        QImage::Format_RGB888));
   data->setPixmap(pixmap);
   dataHash.insert(pagenum, data);
 
@@ -291,12 +323,12 @@ void renderer(Data *data, Renderer *obj)
   fz_drop_device(ctx, dev);
   fz_drop_context(ctx);
 
-  //qDebug() << "Finished rendering:" << pagenum;
+  // qDebug() << "Finished rendering:" << pagenum;
   emit obj->PageLoaded(pagenum);
 }
 
-void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
-  //qDebug() << "- Rendering Page:" << pagenum << degrees;
+void Renderer::renderPage(int pagenum, QSize DPI, int degrees) {
+  // qDebug() << "- Rendering Page:" << pagenum << degrees;
   Data *data;
   fz_matrix matrix;
   fz_rect bbox;
@@ -307,24 +339,24 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
   fz_scale(&matrix, sf, sf);
   fz_pre_rotate(&matrix, degrees);
 
-  pdf_page *PAGE = pdf_load_page(CTX, (pdf_document*)DOC, pagenum);
+  pdf_page *PAGE = pdf_load_page(CTX, (pdf_document *)DOC, pagenum);
   pdf_bound_page(CTX, PAGE, &bbox);
   emit OrigSize(QSizeF(bbox.x1 - bbox.x0, bbox.y1 - bbox.y0));
 
   fz_transform_rect(&bbox, &matrix);
   list = fz_new_display_list(CTX, &bbox);
   fz_device *dev = fz_new_list_device(CTX, list);
-  pdf_run_page_contents(CTX, PAGE, dev, &fz_identity, NULL);  
+  pdf_run_page_contents(CTX, PAGE, dev, &fz_identity, NULL);
 
-  fz_link *link = pdf_load_links(CTX, PAGE); 
+  fz_link *link = pdf_load_links(CTX, PAGE);
   pdf_annot *_annot = pdf_first_annot(CTX, PAGE);
-  QList<Annot*> annotList;
-  QList<Widget*> widgetList;
+  QList<Annot *> annotList;
+  QList<Widget *> widgetList;
 
-  //qDebug() << "Starting annotations for:" << pagenum;
-  while(_annot) {
-    //if(pdf_annot_is_dirty(CTX, _annot))
-      //qDebug() << "DIRTY ANNOT";
+  // qDebug() << "Starting annotations for:" << pagenum;
+  while (_annot) {
+    // if(pdf_annot_is_dirty(CTX, _annot))
+    // qDebug() << "DIRTY ANNOT";
 
     int type = pdf_annot_type(CTX, _annot);
     /**TYPES
@@ -337,7 +369,8 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
       24 = 3D
       -1 = UNKNOWN
     **/
-    //qDebug() << "Page Number:" << pagenum+1 << type << pdf_string_from_annot_type(CTX, (enum pdf_annot_type)type);
+    // qDebug() << "Page Number:" << pagenum+1 << type <<
+    // pdf_string_from_annot_type(CTX, (enum pdf_annot_type)type);
     fz_rect anotBox;
     pdf_bound_annot(CTX, _annot, &anotBox);
     QRectF rect = convertRect(anotBox, sf);
@@ -364,86 +397,100 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
       1 << 8 = TOGGLE_NO_VIEW
       1 << 9 = LOCKED_CONTENTS
     **/
-    
+
     annot->setPrint((flags & PDF_ANNOT_IS_PRINT) == PDF_ANNOT_IS_PRINT);
 
-    char *contents = NULL, *author = NULL; 
-    if(type != 19 and type != 20) {
-      fz_try(CTX){
+    char *contents = NULL, *author = NULL;
+    if (type != 19 and type != 20) {
+      fz_try(CTX) {
         contents = pdf_copy_annot_contents(CTX, _annot);
-        if(contents)
+        if (contents)
           annot->setContents(QString::fromLocal8Bit(contents));
-      }fz_catch(CTX) { }
-      fz_try(CTX){
+      }
+      fz_catch(CTX) {}
+      fz_try(CTX) {
         author = pdf_copy_annot_author(CTX, _annot);
-        if(author)
+        if (author)
           annot->setAuthor(QString::fromLocal8Bit(author));
-      }fz_catch(CTX) { }
+      }
+      fz_catch(CTX) {}
     }
-    //pdf_annot_modification_date(CTX, _annot);
+    // pdf_annot_modification_date(CTX, _annot);
 
-    if(pdf_annot_has_ink_list(CTX, _annot)) {
+    if (pdf_annot_has_ink_list(CTX, _annot)) {
       int inkCount = pdf_annot_ink_list_count(CTX, _annot);
       QVector<QVector<QPointF>> inkList;
-      for(int i = 0; i < inkCount; i++) {
+      for (int i = 0; i < inkCount; i++) {
         int strokeCount = pdf_annot_ink_list_stroke_count(CTX, _annot, i);
         QVector<QPointF> inkPoints;
-        for(int k = 0; k < strokeCount; k++) {
-          fz_point strokeVertex = pdf_annot_ink_list_stroke_vertex(CTX, _annot, i, k);
+        for (int k = 0; k < strokeCount; k++) {
+          fz_point strokeVertex =
+              pdf_annot_ink_list_stroke_vertex(CTX, _annot, i, k);
           QPointF vertexPoint(strokeVertex.x, strokeVertex.y);
-          inkPoints.append(sf*vertexPoint);
+          inkPoints.append(sf * vertexPoint);
         }
         inkList.append(inkPoints);
         annot->setInkList(inkList);
       }
       fz_rect annotRect;
       pdf_annot_rect(CTX, _annot, &annotRect);
-      //qDebug() << "ANNOT RECT:" << convertRect(annotRect, sf);
-      //qDebug() << "INK LIST:" << inkList;
+      // qDebug() << "ANNOT RECT:" << convertRect(annotRect, sf);
+      // qDebug() << "INK LIST:" << inkList;
     }
 
     float color[4] = {0, 0, 0, 1};
     int n;
     fz_try(CTX) {
       pdf_annot_color(CTX, _annot, &n, color);
-      QColor inkColor = QColor(color[0]*255, color[1]*255, color[2]*255, color[3]*255);
+      QColor inkColor = QColor(color[0] * 255, color[1] * 255, color[2] * 255,
+                               color[3] * 255);
       annot->setColor(inkColor);
-      //qDebug() << "COLOR:" << inkColor;
-    }fz_catch(CTX) {
-      //qDebug() << "NO COLOR";
+      // qDebug() << "COLOR:" << inkColor;
+    }
+    fz_catch(CTX) {
+      // qDebug() << "NO COLOR";
       annot->setColor(QColor());
     }
 
-    if(pdf_annot_has_interior_color(CTX, _annot)) {
+    if (pdf_annot_has_interior_color(CTX, _annot)) {
       fz_try(CTX) {
-        color[0] = 0; color[1] = 0; color[2] = 0; color[3] = 1;
+        color[0] = 0;
+        color[1] = 0;
+        color[2] = 0;
+        color[3] = 1;
         pdf_annot_interior_color(CTX, _annot, &n, color);
-        QColor internalColor = QColor(color[0]*255, color[1]*255, color[2]*255, color[3]*255);
-        //qDebug() << "INTERNAL COLOR:" << internalColor;
+        QColor internalColor = QColor(color[0] * 255, color[1] * 255,
+                                      color[2] * 255, color[3] * 255);
+        // qDebug() << "INTERNAL COLOR:" << internalColor;
         annot->setInternalColor(internalColor);
-      }fz_catch(CTX) {
-        //qDebug() << "NO INTERNAL COLOR";
+      }
+      fz_catch(CTX) {
+        // qDebug() << "NO INTERNAL COLOR";
         annot->setInternalColor(QColor());
       }
     }
-    
-    //qDebug() << "BORDER:" << pdf_annot_border(CTX, _annot);
 
-    if(pdf_annot_has_quad_points(CTX, _annot)) {
-      //qDebug() << "HAS QUAD POINTS" << "Page Number:" << pagenum << type;
+    // qDebug() << "BORDER:" << pdf_annot_border(CTX, _annot);
+
+    if (pdf_annot_has_quad_points(CTX, _annot)) {
+      // qDebug() << "HAS QUAD POINTS" << "Page Number:" << pagenum << type;
       int pointCount = pdf_annot_quad_point_count(CTX, _annot);
       QList<QPolygonF> quadList;
-      for(int i = 0; i < pointCount; i++) {
+      for (int i = 0; i < pointCount; i++) {
         float qp[8];
         pdf_annot_quad_point(CTX, _annot, i, qp);
-        QPolygonF quad = QPolygonF(QVector<QPointF>() << QPointF(qp[0], qp[1]) << QPointF(qp[2], qp[3]) << QPointF(qp[4], qp[5]) << QPointF(qp[6], qp[7]));
+        QPolygonF quad =
+            QPolygonF(QVector<QPointF>()
+                      << QPointF(qp[0], qp[1]) << QPointF(qp[2], qp[3])
+                      << QPointF(qp[4], qp[5]) << QPointF(qp[6], qp[7]));
         quadList.append(quad);
       }
       annot->setQuadList(quadList);
     }
-   
-    if(pdf_annot_has_line_ending_styles(CTX, _annot)) {
-      //qDebug() << "HAS LINE ENDING STYLES" << "Page Number:" << pagenum << type;
+
+    if (pdf_annot_has_line_ending_styles(CTX, _annot)) {
+      // qDebug() << "HAS LINE ENDING STYLES" << "Page Number:" << pagenum <<
+      // type;
       pdf_line_ending start, end;
       /**LINE ENDING
         0 = NONE
@@ -453,34 +500,35 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
         9 = SLASH
       **/
       pdf_annot_line_ending_styles(CTX, _annot, &start, &end);
-      //qDebug() << "START:" << start << "END:" << end;
+      // qDebug() << "START:" << start << "END:" << end;
     }
 
-    if(pdf_annot_has_vertices(CTX, _annot)) {
-      //qDebug() << "HAS VERTICIES" << "Page Number:" << pagenum << type;
+    if (pdf_annot_has_vertices(CTX, _annot)) {
+      // qDebug() << "HAS VERTICIES" << "Page Number:" << pagenum << type;
       int vertexCount = pdf_annot_vertex_count(CTX, _annot);
       QList<QPointF> vertexList;
-      for(int i = 0; i < vertexCount; i++) {
+      for (int i = 0; i < vertexCount; i++) {
         fz_point v = pdf_annot_vertex(CTX, _annot, i);
-        vertexList.append(sf*QPointF(v.x, v.y));
+        vertexList.append(sf * QPointF(v.x, v.y));
       }
-      //qDebug() << vertexList;
+      // qDebug() << vertexList;
     }
 
-    if(pdf_annot_has_line(CTX, _annot)) {
+    if (pdf_annot_has_line(CTX, _annot)) {
       fz_point a, b;
       pdf_annot_line(CTX, _annot, &a, &b);
       QPointF pa(a.x, a.y);
       QPointF pb(b.x, b.y);
-      //qDebug() << pa << pb;
+      // qDebug() << pa << pb;
     }
 
-    if(pdf_annot_has_icon_name(CTX, _annot)) {
-      QString iconName = QString::fromLocal8Bit(pdf_annot_icon_name(CTX, _annot));
-      //qDebug() << iconName;
+    if (pdf_annot_has_icon_name(CTX, _annot)) {
+      QString iconName =
+          QString::fromLocal8Bit(pdf_annot_icon_name(CTX, _annot));
+      // qDebug() << iconName;
     }
 
-    if(!pdf_annot_has_ink_list(CTX, _annot)) {
+    if (!pdf_annot_has_ink_list(CTX, _annot)) {
       pdf_run_annot(CTX, _annot, dev, &fz_identity, NULL);
     }
 
@@ -488,8 +536,8 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
     _annot = pdf_next_annot(CTX, _annot);
   }
 
-  pdf_widget *widget = pdf_first_widget(CTX, (pdf_document*)DOC, PAGE);
-  while(widget) {
+  pdf_widget *widget = pdf_first_widget(CTX, (pdf_document *)DOC, PAGE);
+  while (widget) {
     int type = pdf_widget_type(CTX, widget);
     /**
       -1 = NOT_WIDGET
@@ -505,9 +553,10 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
     fz_rect wrect;
     pdf_bound_widget(CTX, widget, &wrect);
     QRectF WRECT = convertRect(wrect, sf);
-    char *currText = pdf_text_widget_text(CTX, (pdf_document*)DOC, widget);
-    int maxLen = pdf_text_widget_max_len(CTX, (pdf_document*)DOC, widget);
-    int contentType = pdf_text_widget_content_type(CTX, (pdf_document*)DOC, widget);
+    char *currText = pdf_text_widget_text(CTX, (pdf_document *)DOC, widget);
+    int maxLen = pdf_text_widget_max_len(CTX, (pdf_document *)DOC, widget);
+    int contentType =
+        pdf_text_widget_content_type(CTX, (pdf_document *)DOC, widget);
     /**
       0 = UNRESTRAINED
       1 = NUMBER
@@ -516,22 +565,30 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
       4 = TIME
     **/
 
-    Widget *WIDGET = new Widget(type, WRECT, QString::fromLocal8Bit(currText), maxLen, contentType); 
-    if(type == 4 or type == 5) {
+    Widget *WIDGET = new Widget(type, WRECT, QString::fromLocal8Bit(currText),
+                                maxLen, contentType);
+    if (type == 4 or type == 5) {
       QStringList optionList, exportList;
-      bool multi = pdf_choice_widget_is_multiselect(CTX, (pdf_document*)DOC, widget);
-     
-      if(int listS = pdf_choice_widget_options(CTX, (pdf_document*)DOC, widget, 0, NULL)) {
+      bool multi =
+          pdf_choice_widget_is_multiselect(CTX, (pdf_document *)DOC, widget);
+
+      if (int listS = pdf_choice_widget_options(CTX, (pdf_document *)DOC,
+                                                widget, 0, NULL)) {
         char *opts[listS];
-        pdf_choice_widget_options(CTX, (pdf_document*)DOC, widget, 0, opts);
-        for(int i = 0; i < listS; i++) { optionList.append(QString::fromLocal8Bit(opts[i])); }
+        pdf_choice_widget_options(CTX, (pdf_document *)DOC, widget, 0, opts);
+        for (int i = 0; i < listS; i++) {
+          optionList.append(QString::fromLocal8Bit(opts[i]));
+        }
         WIDGET->setOptions(optionList);
       }
 
-      if(int exportS = pdf_choice_widget_options(CTX, (pdf_document*)DOC, widget, 1, NULL)) {
+      if (int exportS = pdf_choice_widget_options(CTX, (pdf_document *)DOC,
+                                                  widget, 1, NULL)) {
         char *opts[exportS];
-        pdf_choice_widget_options(CTX, (pdf_document*)DOC, widget, 1, opts);
-        for(int i = 0; i < exportS; i++) { exportList.append(QString::fromLocal8Bit(opts[i])); }
+        pdf_choice_widget_options(CTX, (pdf_document *)DOC, widget, 1, opts);
+        for (int i = 0; i < exportS; i++) {
+          exportList.append(QString::fromLocal8Bit(opts[i]));
+        }
         WIDGET->setExports(exportList);
       }
     }
@@ -543,27 +600,38 @@ void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
 
   fz_close_device(CTX, dev);
   fz_drop_device(CTX, dev);
-  //fz_drop_page(CTX, PAGE);
+  // fz_drop_page(CTX, PAGE);
 
-  data = new Data(pagenum, CTX, list, bbox, matrix, sf, link, annotList, widgetList);
+  data = new Data(pagenum, CTX, list, bbox, matrix, sf, link, annotList,
+                  widgetList);
   data->setRenderThread(QtConcurrent::run(&renderer, data, this));
 }
 
-QList<TextData*> Renderer::searchDocument(QString text, bool matchCase){
+QList<TextData *> Renderer::searchDocument(QString text, bool matchCase) {
   fz_rect rectBuffer[1000];
-  QList<TextData*> results;
-  for(int i = 0; i < pnum; i++) {
-    int count = fz_search_display_list(CTX, dataHash[i]->getDisplayList(), text.toLocal8Bit().data(), rectBuffer, 1000);
-    //qDebug() << "Page " << i+1 << ": Count, " << count;
-    for(int j = 0; j < count; j++) {
-      TextData *t = new TextData(dataHash[i]->getScaledRect(rectBuffer[j]), i+1, text);
-      //MuPDF search does not match case, so retrieve the exact text at the location found and determine whether or not it matches the case of the search text if the user selected to match case
-      if(matchCase){
-        fz_stext_page *sPage = fz_new_stext_page_from_display_list(CTX, dataHash[i]->getDisplayList(), NULL);
-        QString currentStr = QString(fz_copy_selection(CTX, sPage, *fz_rect_min(&rectBuffer[j]), *fz_rect_max(&rectBuffer[j]), false));
-        if(currentStr.contains(text, Qt::CaseSensitive)){ results.append(t); }
-      }else{
+  QList<TextData *> results;
+  for (int i = 0; i < pnum; i++) {
+    int count =
+        fz_search_display_list(CTX, dataHash[i]->getDisplayList(),
+                               text.toLocal8Bit().data(), rectBuffer, 1000);
+    // qDebug() << "Page " << i+1 << ": Count, " << count;
+    for (int j = 0; j < count; j++) {
+      TextData *t =
+          new TextData(dataHash[i]->getScaledRect(rectBuffer[j]), i + 1, text);
+      // MuPDF search does not match case, so retrieve the exact text at the
+      // location found and determine whether or not it matches the case of the
+      // search text if the user selected to match case
+      if (matchCase) {
+        fz_stext_page *sPage = fz_new_stext_page_from_display_list(
+            CTX, dataHash[i]->getDisplayList(), NULL);
+        QString currentStr =
+            QString(fz_copy_selection(CTX, sPage, *fz_rect_min(&rectBuffer[j]),
+                                      *fz_rect_max(&rectBuffer[j]), false));
+        if (currentStr.contains(text, Qt::CaseSensitive)) {
           results.append(t);
+        }
+      } else {
+        results.append(t);
       }
     }
   }
@@ -574,16 +642,14 @@ QImage Renderer::imageHash(int pagenum) {
   return dataHash[pagenum]->getImage();
 }
 
-int Renderer::hashSize() {
-  return dataHash.size();
-}
+int Renderer::hashSize() { return dataHash.size(); }
 
 void Renderer::clearHash() {
   qDeleteAll(dataHash);
   dataHash.clear();
 }
 
-TextData* Renderer::linkList(int pagenum, int entry) {
+TextData *Renderer::linkList(int pagenum, int entry) {
   return dataHash[pagenum]->getLinkList()[entry]->getData();
 }
 
@@ -592,7 +658,7 @@ int Renderer::linkSize(int pagenum) {
 }
 
 Annotation *Renderer::annotList(int pagenum, int entry) {
-  return static_cast<Annotation*>(dataHash[pagenum]->getAnnotList(entry));
+  return static_cast<Annotation *>(dataHash[pagenum]->getAnnotList(entry));
 }
 
 int Renderer::annotSize(int pagenum) {

--- a/src-qt5/desktop-utils/lumina-pdf/Renderer-poppler.cpp
+++ b/src-qt5/desktop-utils/lumina-pdf/Renderer-poppler.cpp
@@ -1,82 +1,86 @@
 #include "Renderer.h"
-#include <poppler/qt5/poppler-qt5.h>
+#include "drawablepage.h"
+#include "link.h"
+#include "lrucache.h"
 #include <QThread>
+#include <atomic>
+#include <poppler/qt5/poppler-qt5.h>
 
-class Link {
-  public:
-    Link(TextData *_data, Poppler::Link *_link) : data(_data), link(_link) { }
-    ~Link() { delete data; }
-
-    TextData* getData() { return data; }
-    Poppler::Link* getLink() { return link; }
-
-  private:
-    TextData *data;
-    Poppler::Link *link;
-};
-
-static Poppler::Document *DOC;
+static std::unique_ptr<Poppler::Document> DOC;
 QHash<int, QImage> loadingHash;
-QHash<int, QList<Link*>> linkHash;
 
-Renderer::Renderer(){
-  DOC = 0;
-  needpass = false;
-  pnum = 0;
-	degrees = 0;
+static std::vector<LuminaPDF::drawablePage> pages;
+static std::vector<QList<LuminaPDF::Link *>> links;
+static std::atomic<int> pagesStillLoading;
+static QHash<int, QList<LuminaPDF::Link *>> linkHash;
+static LuminaPDF::LRUCache<QImage> imageCache;
+
+Renderer::Renderer() : pnum(0), needpass(false), degrees(0) {
+  DOC.reset(nullptr);
+  pagesStillLoading = 1;
+  imageCache.setCacheSize(5);
 }
 
-Renderer::~Renderer(){
-  //qDeleteAll(loadingHash);
+Renderer::~Renderer() {
+  // qDeleteAll(loadingHash);
+  pages.clear();
+  for (auto &linkList : links) {
+    qDeleteAll(linkList);
+  }
   loadingHash.clear();
 }
 
-bool Renderer::loadMultiThread(){ return true; }
+bool Renderer::loadMultiThread() { return true; }
 
 /*QJsonObject Renderer::properties(){
   return QJsonObject(); //TO-DO
 }*/
 
-bool Renderer::loadDocument(QString path, QString password){
-  //qDebug() << "Load Document:" << path;
-  if(DOC!=0 && path!=docpath){
-    //Clear out the old document first
-    delete DOC;
-    DOC=0;
-    if(linkHash.size() > 0) {
-      foreach(QList<Link*> linkArray, linkHash) {
+bool Renderer::loadDocument(QString path, QString password) {
+  // qDebug() << "Load Document:" << path;
+  if (DOC != nullptr && path != docpath) {
+    // Clear out the old document first
+    DOC.reset(nullptr);
+    pages.clear();
+    if (linkHash.size() > 0) {
+      foreach (QList<LuminaPDF::Link *> linkArray, linkHash) {
         qDeleteAll(linkArray);
       }
       linkHash.clear();
     }
     needpass = false;
-    pnum=0;
+    pnum = 0;
     docpath = path;
   }
-  //Load the Document (if needed);
-  if(DOC==0){
-    //qDebug() << "Loading Document";
-    DOC = Poppler::Document::load(path);
+  // Load the Document (if needed);
+  if (DOC == nullptr) {
+    // qDebug() << "Loading Document";
+    DOC.reset(Poppler::Document::load(path));
     docpath = path;
   }
 
-  if(DOC==0){
+  if (DOC == nullptr) {
     qDebug() << "Could not open file:" << path;
     return false;
-  }else if(DOC->isLocked()){
-    //qDebug() << "Document Locked";
-    needpass = true;
-    if(password.isEmpty()){ return false; } //stop here - need to get password from user before continuing
-    needpass = !DOC->unlock(QByteArray(), password.toLocal8Bit());
-    if(needpass){ return false; } //invalid password
   }
-  //qDebug() << "Opening File:" << path;
+
+  if (DOC->isLocked()) {
+    // qDebug() << "Document Locked";
+    needpass = true;
+    if (password.isEmpty() or
+        !DOC->unlock(QByteArray(), password.toLocal8Bit())) {
+      return false;
+    } // invalid password
+  }
+  // qDebug() << "Opening File:" << path;
   doctitle = DOC->title();
-  if(doctitle.isEmpty()){ doctitle = path.section("/",-1); }
+  if (doctitle.isEmpty()) {
+    doctitle = path.section("/", -1);
+  }
   pnum = DOC->numPages();
-  //Setup the Document
+  // Setup the Document
   Poppler::Page *PAGE = DOC->page(0);
-  if(PAGE!=0){
+  if (PAGE != 0) {
     /*switch(PAGE->orientation()){
       case Poppler::Page::Landscape:
         WIDGET->setOrientation(QPageLayout::Landscape); break;
@@ -84,62 +88,93 @@ bool Renderer::loadDocument(QString path, QString password){
         WIDGET->setOrientation(QPageLayout::Portrait);
     }*/
     delete PAGE;
-    return true; //could load the first page
+    pages.reserve(pnum + 1);
+
+    for (int i = 0; i < pnum + 1; ++i) {
+      LuminaPDF::drawablePage temp;
+      pages.emplace_back(std::move(temp));
+    }
+
+    for (int i = 0; i < pnum + 1; ++i) {
+      QList<LuminaPDF::Link *> temp;
+      links.push_back(temp);
+    }
+
+    pagesStillLoading = pnum;
+
+    return true; // could load the first page
   }
-  return false; //nothing to load
+  return false; // nothing to load
 }
 
-void Renderer::renderPage(int pagenum, QSize DPI, int degrees){
-  //qDebug() << "Render Page:" << pagenum << DPI << degrees;
+void Renderer::renderPage(int pagenum, QSize DPI, int degrees) {
+  // qDebug() << "Render Page:" << pagenum << DPI << degrees;
 
-  if(DOC!=0){
-    Poppler::Page *PAGE = DOC->page(pagenum);
+  emit SetProgress(pages.size() - pagesStillLoading);
+
+  if (DOC != nullptr) {
+    Poppler::Page *PAGE = DOC->page(pagenum - 1);
     QImage img;
-    if(PAGE!=0){
-			Poppler::Page::Rotation rotation;
-			switch(degrees) {
-				case 90:
-					rotation = Poppler::Page::Rotation::Rotate90;
-					break;
-				case 180:
-					rotation = Poppler::Page::Rotation::Rotate180;
-					break;
-				case 270:
-					rotation = Poppler::Page::Rotation::Rotate270;
-					break;
-				default:
-					rotation = Poppler::Page::Rotation::Rotate0;
-			}
-      img = PAGE->renderToImage(DPI.width(), DPI.height(), -1, -1, -1, -1, rotation);
-      loadingHash.insert(pagenum, img);
-      QList<Link*> linkArray;
-      foreach(Poppler::Link *link, PAGE->links()) {
+    if (PAGE != nullptr) {
+      Poppler::Page::Rotation rotation;
+      switch (degrees) {
+      case 90:
+        rotation = Poppler::Page::Rotation::Rotate90;
+        break;
+      case 180:
+        rotation = Poppler::Page::Rotation::Rotate180;
+        break;
+      case 270:
+        rotation = Poppler::Page::Rotation::Rotate270;
+        break;
+      default:
+        rotation = Poppler::Page::Rotation::Rotate0;
+      }
+
+      LuminaPDF::drawablePage temp(PAGE, DPI, rotation);
+      pages[pagenum] = std::move(temp);
+      // img = PAGE->renderToImage(DPI.width(), DPI.height(), -1, -1, -1, -1,
+      //                          rotation);
+      // loadingHash.insert(pagenum, img);
+      QList<LuminaPDF::Link *> linkArray;
+
+      foreach (Poppler::Link *link, PAGE->links()) {
         QString location;
-        if(link->linkType() == Poppler::Link::LinkType::Goto)
-          location = dynamic_cast<Poppler::LinkGoto*>(link)->fileName();
-        else if(link->linkType() == Poppler::Link::LinkType::Goto)
-          location = dynamic_cast<Poppler::LinkBrowse*>(link)->url();
-        Link *newLink = new Link(new TextData(link->linkArea(), pagenum, location), link);
+        if (link->linkType() == Poppler::Link::LinkType::Goto)
+          location = dynamic_cast<Poppler::LinkGoto *>(link)->fileName();
+        else if (link->linkType() == Poppler::Link::LinkType::Goto)
+          location = dynamic_cast<Poppler::LinkBrowse *>(link)->url();
+        LuminaPDF::Link *newLink = new LuminaPDF::Link(
+            new TextData(link->linkArea(), pagenum, location), link);
         linkArray.append(newLink);
       }
-      linkHash.insert(pagenum, linkArray);
-      delete PAGE;
+
+      links[pagenum] = linkArray;
+      // linkHash.insert(pagenum, linkArray);
     }
-    //qDebug() << "Done Render Page:" << pagenum << img.size();
-  }else{
-    loadingHash.insert(pagenum, QImage());
+    // qDebug() << "Done Render Page:" << pagenum << img.size();
+  } else {
+    pages[pagenum] = LuminaPDF::drawablePage();
+    // loadingHash.insert(pagenum, QImage());
   }
-  emit PageLoaded(pagenum);
+
+  if (pagesStillLoading == 1) {
+    emit PageLoaded();
+  }
+
+  --pagesStillLoading;
 }
 
-QList<TextData*> Renderer::searchDocument(QString text, bool matchCase){
-  QList<TextData*> results;
-  for(int i = 0; i < pnum; i++) {
-    QList<Poppler::TextBox*> textList = DOC->page(i)->textList();
-    for(int j = 0; j < textList.size(); j++) {
-      if(textList[j]->text().contains(text, 
-      (matchCase) ? Qt::CaseSensitive : Qt::CaseInsensitive)) {
-        TextData *t = new TextData(textList[j]->boundingBox(), i+1, text);
+bool Renderer::isDoneLoading() { return pagesStillLoading == 0; }
+
+QList<TextData *> Renderer::searchDocument(QString text, bool matchCase) {
+  QList<TextData *> results;
+  for (int i = 0; i < pnum; i++) {
+    QList<Poppler::TextBox *> textList = DOC->page(i)->textList();
+    for (int j = 0; j < textList.size(); j++) {
+      if (textList[j]->text().contains(
+              text, (matchCase) ? Qt::CaseSensitive : Qt::CaseInsensitive)) {
+        TextData *t = new TextData(textList[j]->boundingBox(), i + 1, text);
         results.append(t);
       }
     }
@@ -147,59 +182,87 @@ QList<TextData*> Renderer::searchDocument(QString text, bool matchCase){
   return results;
 }
 
+QSize Renderer::imageSize(int pagenum) { return pages[pagenum].size(); }
+
 QImage Renderer::imageHash(int pagenum) {
-  return loadingHash[pagenum];
+  // while(pagesStillLoading > 0) { qDebug() << "pagesStillLoading!\n";}
+
+  std::optional<QImage> cachedImage = imageCache.get(pagenum);
+
+  if (cachedImage.has_value())
+    return *cachedImage;
+
+  imageCache.push(pagenum, pages[pagenum].render());
+  return *imageCache.get(pagenum);
 }
 
 int Renderer::hashSize() {
-  return loadingHash.keys().length();
+  qDebug() << "pages contains " << pages.size() << " elements.\n";
+  return pages.size();
 }
 
 void Renderer::clearHash() {
   loadingHash.clear();
+  pages.clear();
 }
 
-//Highlighting found text, bookmarks, and page properties disabled for Poppler
+// Highlighting found text, bookmarks, and page properties disabled for Poppler
 bool Renderer::supportsExtraFeatures() { return false; }
 
-void Renderer::traverseOutline(void *, int) { }
+void Renderer::traverseOutline(void *, int) {}
 
 void Renderer::handleLink(QWidget *obj, QString linkDest) {
-  Poppler::Link* trueLink;
-  foreach(QList<Link*> linkArray, linkHash) {
-    for(int i = 0; i < linkArray.size(); i++) {
-      Poppler::Link* link = linkArray[i]->getLink();
-      if(link->linkType() == Poppler::Link::LinkType::Browse) {
-        if(linkDest == dynamic_cast<Poppler::LinkBrowse*>(link)->url())
+  Poppler::Link *trueLink;
+  foreach (QList<LuminaPDF::Link *> linkArray, linkHash) {
+    for (int i = 0; i < linkArray.size(); i++) {
+      Poppler::Link *link = linkArray[i]->getLink();
+      if (link->linkType() == Poppler::Link::LinkType::Browse) {
+        if (linkDest == dynamic_cast<Poppler::LinkBrowse *>(link)->url())
           trueLink = link;
-      }else if(link->linkType() == Poppler::Link::LinkType::Goto) {
-        if(linkDest == dynamic_cast<Poppler::LinkGoto*>(link)->fileName())
+      } else if (link->linkType() == Poppler::Link::LinkType::Goto) {
+        if (linkDest == dynamic_cast<Poppler::LinkGoto *>(link)->fileName())
           trueLink = link;
       }
     }
   }
-  if(trueLink) {
-    if(trueLink->linkType() == Poppler::Link::LinkType::Goto)
-      emit goToPosition(dynamic_cast<Poppler::LinkGoto*>(trueLink)->destination().pageNumber(), 0, 0);
-    else if(trueLink->linkType() == Poppler::Link::LinkType::Browse) {
-      if(QMessageBox::Yes == QMessageBox::question(obj, tr("Open External Link?"), QString(tr("Do you want to open %1 in the default browser")).arg(linkDest), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) ){ QProcess::startDetached("firefox \""+linkDest+"\""); }
+  if (trueLink) {
+    if (trueLink->linkType() == Poppler::Link::LinkType::Goto)
+      emit goToPosition(dynamic_cast<Poppler::LinkGoto *>(trueLink)
+                            ->destination()
+                            .pageNumber(),
+                        0, 0);
+    else if (trueLink->linkType() == Poppler::Link::LinkType::Browse) {
+      if (QMessageBox::Yes ==
+          QMessageBox::question(
+              obj, tr("Open External Link?"),
+              QString(tr("Do you want to open %1 in the default browser"))
+                  .arg(linkDest),
+              QMessageBox::Yes | QMessageBox::No, QMessageBox::No)) {
+        QProcess::startDetached("firefox \"" + linkDest + "\"");
+      }
     }
   }
 }
 
-TextData* Renderer::linkList(int pageNum, int entry) {
-  if(linkHash[pageNum].size() > 0)
+TextData *Renderer::linkList(int pageNum, int entry) {
+  if (linkHash[pageNum].size() > 0)
     return linkHash[pageNum][entry]->getData();
   else
     return 0;
 }
 
-int Renderer::linkSize(int pageNum) { Q_UNUSED(pageNum) return linkHash[pageNum].size(); }
+int Renderer::linkSize(int pageNum) {
+  Q_UNUSED(pageNum) return linkHash[pageNum].size();
+}
 
 int Renderer::annotSize(int pageNum) { Q_UNUSED(pageNum) return 0; }
 
-Annotation *Renderer::annotList(int pageNum, int entry) { Q_UNUSED(pageNum) Q_UNUSED(entry) return NULL; }
+Annotation *Renderer::annotList(int pageNum, int entry) {
+  Q_UNUSED(pageNum) Q_UNUSED(entry) return NULL;
+}
 
 int Renderer::widgetSize(int pageNum) { Q_UNUSED(pageNum) return 0; }
 
-Widget *Renderer::widgetList(int pageNum, int entry) { Q_UNUSED(pageNum) Q_UNUSED(entry) return NULL; }
+Widget *Renderer::widgetList(int pageNum, int entry) {
+  Q_UNUSED(pageNum) Q_UNUSED(entry) return NULL;
+}

--- a/src-qt5/desktop-utils/lumina-pdf/Renderer.h
+++ b/src-qt5/desktop-utils/lumina-pdf/Renderer.h
@@ -1,4 +1,5 @@
-// ================================ // Simple abstraction class between backend renderers
+// ================================ // Simple abstraction class between backend
+// renderers
 // ================================
 // Written by Ken Moore: Feb 26, 2018
 // Available under the 3-Clause BSD License
@@ -6,50 +7,51 @@
 #ifndef _LUMINA_PDF_BACKEND_RENDERER_H
 #define _LUMINA_PDF_BACKEND_RENDERER_H
 
-#include <QString>
-#include <QImage>
+#include "Annotation.h"
+#include "Bookmark.h"
+#include "TextData.h"
+#include "Widget.h"
 #include <QDebug>
+#include <QImage>
 #include <QJsonObject>
 #include <QMessageBox>
 #include <QProcess>
-#include "TextData.h"
-#include "Bookmark.h"
-#include "Annotation.h"
-#include "Widget.h"
+#include <QString>
 
 class Renderer : public QObject {
-Q_OBJECT
+  Q_OBJECT
 
 private:
-  int pnum; //number of pages - set on loading document
+  int pnum; // number of pages - set on loading document
   bool needpass;
-  QString docpath; //save the path for the currently-loaded document
+  QString docpath; // save the path for the currently-loaded document
   QString doctitle;
   QJsonObject jobj;
-	int degrees;
-  QList<Bookmark*> bookmarks;
+  int degrees;
+  QList<Bookmark *> bookmarks;
 
 public:
   Renderer();
   ~Renderer();
   bool loadMultiThread();
 
-  //Information functions (usually needs to be loaded first)
-  virtual int numPages(){ return pnum; }
-  virtual bool needPassword(){ return needpass; }
-  virtual QString title(){ return doctitle; }
+  // Information functions (usually needs to be loaded first)
+  virtual int numPages() { return pnum; }
+  virtual bool needPassword() { return needpass; }
+  virtual QString title() { return doctitle; }
   virtual QJsonObject properties() { return jobj; }
   virtual int hashSize();
   virtual QImage imageHash(int pagenum);
-	virtual int rotatedDegrees() { return degrees; }
-  virtual QList<Bookmark*> getBookmarks() { return bookmarks; }
+  virtual QSize imageSize(int pagenum);
+  virtual int rotatedDegrees() { return degrees; }
+  virtual QList<Bookmark *> getBookmarks() { return bookmarks; }
 
-  //Main access functions
+  // Main access functions
   virtual bool loadDocument(QString path, QString password);
-  virtual void renderPage(int pagenum, QSize DPI, int degrees=0);
-  virtual QList<TextData*> searchDocument(QString text, bool matchCase);
+  virtual void renderPage(int pagenum, QSize DPI, int degrees = 0);
+  virtual QList<TextData *> searchDocument(QString text, bool matchCase);
   virtual void traverseOutline(void *, int);
-  virtual void handleLink(QWidget*, QString);
+  virtual void handleLink(QWidget *, QString);
   virtual TextData *linkList(int, int);
   virtual int linkSize(int);
   virtual Annotation *annotList(int, int);
@@ -57,20 +59,22 @@ public:
   virtual Widget *widgetList(int, int);
   virtual int widgetSize(int);
 
-	virtual void clearHash();
-  //Makes sure degrees is between 0 and 360 then rotates the matrix and 
+  virtual void clearHash();
+  // Makes sure degrees is between 0 and 360 then rotates the matrix and
   void setDegrees(int degrees) {
-    //Mods by 360, but adds and remods because of how C++ treats negative mods
-    this->degrees = ( ( ( this->degrees + degrees ) % 360 ) + 360 ) % 360;
+    // Mods by 360, but adds and remods because of how C++ treats negative mods
+    this->degrees = (((this->degrees + degrees) % 360) + 360) % 360;
     emit reloadPages(this->degrees);
   }
 
+  virtual bool isDoneLoading();
   virtual bool supportsExtraFeatures();
 
 signals:
-  void PageLoaded(int);
+  void PageLoaded();
+  void SetProgress(int);
   void OrigSize(QSizeF);
-	void reloadPages(int);
+  void reloadPages(int);
   void goToPosition(int, float, float);
 };
 

--- a/src-qt5/desktop-utils/lumina-pdf/TextData.h
+++ b/src-qt5/desktop-utils/lumina-pdf/TextData.h
@@ -4,32 +4,30 @@
 #include <QRect>
 
 class TextData {
-  private:
-    QRectF p_loc;
-    bool p_highlighted=false;
-    int p_page=0;
-    QString p_text="";
-		//int p_degrees=0;
+private:
+  QRectF p_loc;
+  bool p_highlighted = false;
+  int p_page = 0;
+  QString p_text = "";
+  // int p_degrees=0;
 
-  public:
-    TextData(QRectF _loc, int _page, QString _text) :
-				p_loc(_loc),
-        p_page(_page),
-        p_text(_text)
-			  //p_degrees(_degrees)
-    { }
+public:
+  TextData(QRectF _loc, int _page, QString _text)
+      : p_loc(_loc), p_page(_page), p_text(_text)
+  // p_degrees(_degrees)
+  {}
 
-    QRectF loc() { return p_loc; }
-    bool highlighted() { return p_highlighted; }
-    int page() { return p_page; }
-    QString text() { return p_text; }
-    //int degrees() { return p_degrees; }
-    
-    void loc(QRect loc) { p_loc = loc; }
-    void highlighted(bool highlighted) { p_highlighted = highlighted; }
-    void page(int page) { p_page = page; }
-    void text(QString text) { p_text = text; }
-    //void degrees(int degrees) { p_degrees = degrees; }
+  QRectF loc() { return p_loc; }
+  bool highlighted() { return p_highlighted; }
+  int page() { return p_page; }
+  QString text() { return p_text; }
+  // int degrees() { return p_degrees; }
+
+  void loc(QRect loc) { p_loc = loc; }
+  void highlighted(bool highlighted) { p_highlighted = highlighted; }
+  void page(int page) { p_page = page; }
+  void text(QString text) { p_text = text; }
+  // void degrees(int degrees) { p_degrees = degrees; }
 };
 
 #endif

--- a/src-qt5/desktop-utils/lumina-pdf/Widget.h
+++ b/src-qt5/desktop-utils/lumina-pdf/Widget.h
@@ -1,29 +1,32 @@
 #include <QStringList>
 
-class Widget{
-  public:
-    Widget(int _widgetType, QRectF _loc, QString _currText, int _maxLen, int _contentType) : widgetType(_widgetType), loc(_loc), currText(_currText), maxLen(_maxLen), contentType(_contentType) { }
+class Widget {
+public:
+  Widget(int _widgetType, QRectF _loc, QString _currText, int _maxLen,
+         int _contentType)
+      : widgetType(_widgetType), loc(_loc), currText(_currText),
+        maxLen(_maxLen), contentType(_contentType) {}
 
-    virtual ~Widget() { }
+  virtual ~Widget() {}
 
-    virtual int getWidgetType() { return widgetType; }
-    virtual QRectF getLocation() { return loc; }
-    virtual QString getCurrentText() { return currText; }
-    virtual int  getMaxLength() { return maxLen; }
-    virtual int getContentType() { return contentType; }
-    virtual QStringList getOptionList() { return optionList; }
-    virtual QStringList getExportList() { return exportList; }
+  virtual int getWidgetType() { return widgetType; }
+  virtual QRectF getLocation() { return loc; }
+  virtual QString getCurrentText() { return currText; }
+  virtual int getMaxLength() { return maxLen; }
+  virtual int getContentType() { return contentType; }
+  virtual QStringList getOptionList() { return optionList; }
+  virtual QStringList getExportList() { return exportList; }
 
-    virtual void setOptions(QStringList _optionList) { optionList = _optionList; }
-    virtual void setExports(QStringList _exportList) { exportList = _exportList; }
+  virtual void setOptions(QStringList _optionList) { optionList = _optionList; }
+  virtual void setExports(QStringList _exportList) { exportList = _exportList; }
 
-  private:
-    int widgetType;
-    QRectF loc;
-    QString currText;
-    int maxLen;
-    int contentType;
+private:
+  int widgetType;
+  QRectF loc;
+  QString currText;
+  int maxLen;
+  int contentType;
 
-    QStringList optionList;
-    QStringList exportList;
+  QStringList optionList;
+  QStringList exportList;
 };

--- a/src-qt5/desktop-utils/lumina-pdf/drawablepage.h
+++ b/src-qt5/desktop-utils/lumina-pdf/drawablepage.h
@@ -1,0 +1,41 @@
+#ifndef LUMINA_PDF_DRAWABLEPAGE_H
+#define LUMINA_PDF_DRAWABLEPAGE_H
+
+#include <QImage>
+#include <QSize>
+#include <poppler/qt5/poppler-qt5.h>
+
+namespace LuminaPDF {
+
+class drawablePage {
+public:
+  drawablePage()
+      : page(nullptr), DPI(0.0, 0.0), rotation(Poppler::Page::Rotate0) {}
+  drawablePage(Poppler::Page *_page, QSize _DPI,
+               Poppler::Page::Rotation _rotation)
+      : page(_page), DPI(_DPI), rotation(_rotation) {}
+
+  drawablePage(const LuminaPDF::drawablePage &other) = delete;
+  LuminaPDF::drawablePage &
+  operator=(const LuminaPDF::drawablePage &other) = delete;
+
+  drawablePage(LuminaPDF::drawablePage &&other) = default;
+  LuminaPDF::drawablePage &operator=(LuminaPDF::drawablePage &&other) = default;
+  ~drawablePage() = default;
+
+  QImage render() {
+    return page->renderToImage(DPI.width(), DPI.height(), -1, -1, -1, -1,
+                               rotation);
+  }
+
+  QSize size() { return page->pageSize(); }
+
+private:
+  std::unique_ptr<Poppler::Page> page;
+  QSize DPI;
+  Poppler::Page::Rotation rotation;
+};
+
+} // namespace LuminaPDF
+
+#endif // LUMINA_PDF_DRAWABLEPAGE_H

--- a/src-qt5/desktop-utils/lumina-pdf/graphicsitems.h
+++ b/src-qt5/desktop-utils/lumina-pdf/graphicsitems.h
@@ -1,0 +1,190 @@
+#ifndef LUMINA_PDF_GRAPHICSITEMS_H
+#define LUMINA_PDF_GRAPHICSITEMS_H
+
+#include <QGraphicsItem>
+#include <QPainter>
+#include <QStyleOption>
+#include <QTextDocument>
+
+class InkItem : public QGraphicsItem {
+public:
+  InkItem(QGraphicsItem *parent, Annotation *_annot)
+      : QGraphicsItem(parent), pointData(_annot->getInkList()),
+        inkColor(_annot->getColor()), annot(_annot) {
+    setCacheMode(DeviceCoordinateCache);
+    bbox = annot->getLoc();
+  }
+
+  QRectF boundingRect() const Q_DECL_OVERRIDE { return bbox; }
+
+  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+             QWidget *widget) Q_DECL_OVERRIDE {
+    Q_UNUSED(widget);
+    painter->setClipRect(option->exposedRect);
+    QPen inkPen = QPen(inkColor);
+    painter->setPen(inkPen);
+    foreach (QVector<QPointF> pointList, pointData) {
+      painter->drawLines(pointList);
+    }
+  }
+
+private:
+  QRectF bbox;
+  QVector<QVector<QPointF>> pointData;
+  QColor inkColor;
+  Annotation *annot;
+};
+
+class PopupItem : public QGraphicsItem {
+public:
+  PopupItem(QGraphicsItem *parent, Annotation *_annot)
+      : QGraphicsItem(parent), author(_annot->getAuthor()),
+        text(_annot->getText()) {
+    QRectF loc = _annot->getLoc();
+    setCacheMode(DeviceCoordinateCache);
+    QString allText = "Author: " + author + "\n\n" + text;
+    QTextDocument document;
+    document.setDefaultFont(QFont("Helvitica", 10, QFont::Normal));
+    document.setPageSize(QSize(120, 120));
+    document.setHtml(allText);
+    loc.moveTopLeft(
+        QPointF(loc.center().x(), loc.center().y() + loc.height() / 2));
+    loc.setSize(document.size() + QSize(10, 10));
+    bbox = loc;
+  }
+
+  QRectF boundingRect() const Q_DECL_OVERRIDE { return bbox; }
+
+  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+             QWidget *widget) Q_DECL_OVERRIDE {
+    Q_UNUSED(widget);
+    QString allText = "Author: " + author + "\n\n" + text;
+    painter->setClipRect(option->exposedRect);
+    painter->setFont(QFont("Helvitica", 10, QFont::Normal));
+    painter->setBrush(QBrush(QColor(255, 255, 177, 255)));
+    painter->drawRect(bbox);
+    painter->setPen(QPen(QColor("Black")));
+    painter->drawText(bbox, Qt::AlignLeft | Qt::TextWordWrap, allText);
+  }
+
+private:
+  QRectF bbox;
+  QString author;
+  QString text;
+};
+
+class AnnotZone : public QGraphicsItem {
+public:
+  AnnotZone(QGraphicsItem *parent, Annotation *_annot, PopupItem *_annotItem)
+      : QGraphicsItem(parent), bbox(_annot->getLoc()), annot(_annotItem) {
+    _hasText = !_annot->getText().isEmpty();
+    _hasAuthor = !_annot->getAuthor().isEmpty();
+  }
+
+  QRectF boundingRect() const Q_DECL_OVERRIDE { return bbox; }
+  PopupItem *annotation() const { return annot; }
+  bool hasText() const { return _hasText; }
+  bool hasAuthor() const { return _hasAuthor; }
+  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+             QWidget *widget) Q_DECL_OVERRIDE {
+    Q_UNUSED(widget);
+    Q_UNUSED(painter);
+    Q_UNUSED(option);
+  }
+
+private:
+  QRectF bbox;
+  PopupItem *annot;
+  bool _hasText;
+  bool _hasAuthor;
+};
+
+class LinkItem : public QGraphicsItem {
+public:
+  LinkItem(QGraphicsItem *parent, TextData *_data)
+      : QGraphicsItem(parent), bbox(_data->loc()), data(_data) {
+    setCacheMode(DeviceCoordinateCache);
+    setAcceptHoverEvents(true);
+  }
+
+  QRectF boundingRect() const Q_DECL_OVERRIDE { return bbox; }
+
+  inline TextData *getData() const { return data; }
+
+  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+             QWidget *widget) Q_DECL_OVERRIDE {
+    Q_UNUSED(widget);
+    painter->setClipRect(option->exposedRect);
+    painter->setBrush(QBrush(QColor(255, 255, 177, 100)));
+    painter->setPen(QPen(QColor(255, 255, 100, 125)));
+    painter->drawRect(bbox);
+  }
+
+private:
+  QRectF bbox;
+  TextData *data;
+};
+
+class PageItem : public QGraphicsItem {
+public:
+  PageItem(int _pageNum, QImage _pagePicture, QSize _paperSize,
+           Renderer *_backend)
+      : pageNum(_pageNum), pagePicture(_pagePicture), paperSize(_paperSize),
+        BACKEND(_backend) {
+    brect = QRectF(QPointF(-25, -25), QSizeF(paperSize) + QSizeF(50, 50));
+    setCacheMode(DeviceCoordinateCache);
+    setAcceptHoverEvents(true);
+  }
+
+  QRectF boundingRect() const Q_DECL_OVERRIDE { return brect; }
+
+  inline int pageNumber() const { return pageNum; }
+
+  void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+             QWidget *widget) Q_DECL_OVERRIDE {
+    Q_UNUSED(widget);
+    // Ensure all the antialiasing/smoothing options are turned on
+    painter->setRenderHint(QPainter::Antialiasing);
+    painter->setRenderHint(QPainter::TextAntialiasing);
+    painter->setRenderHint(QPainter::SmoothPixmapTransform);
+
+    QRectF paperRect(0, 0, paperSize.width(), paperSize.height());
+    // Draw shadow
+    painter->setClipRect(option->exposedRect);
+    qreal shWidth = paperRect.width() / 100;
+    QRectF rshadow(paperRect.topRight() + QPointF(0, shWidth),
+                   paperRect.bottomRight() + QPointF(shWidth, 0));
+    QLinearGradient rgrad(rshadow.topLeft(), rshadow.topRight());
+    rgrad.setColorAt(0.0, QColor(0, 0, 0, 255));
+    rgrad.setColorAt(1.0, QColor(0, 0, 0, 0));
+    painter->fillRect(rshadow, QBrush(rgrad));
+    QRectF bshadow(paperRect.bottomLeft() + QPointF(shWidth, 0),
+                   paperRect.bottomRight() + QPointF(0, shWidth));
+    QLinearGradient bgrad(bshadow.topLeft(), bshadow.bottomLeft());
+    bgrad.setColorAt(0.0, QColor(0, 0, 0, 255));
+    bgrad.setColorAt(1.0, QColor(0, 0, 0, 0));
+    painter->fillRect(bshadow, QBrush(bgrad));
+    QRectF cshadow(paperRect.bottomRight(),
+                   paperRect.bottomRight() + QPointF(shWidth, shWidth));
+    QRadialGradient cgrad(cshadow.topLeft(), shWidth, cshadow.topLeft());
+    cgrad.setColorAt(0.0, QColor(0, 0, 0, 255));
+    cgrad.setColorAt(1.0, QColor(0, 0, 0, 0));
+    painter->fillRect(cshadow, QBrush(cgrad));
+    painter->setClipRect(paperRect & option->exposedRect);
+    painter->fillRect(paperRect, Qt::white);
+    painter->drawImage(QPoint(0, 0), pagePicture);
+    for (int k = 0; k < BACKEND->annotSize(pageNum - 1); k++) {
+      Annotation *annot = BACKEND->annotList(pageNum - 1, k);
+      painter->drawImage(annot->getLoc(), annot->renderImage());
+    }
+  }
+
+private:
+  int pageNum;
+  QImage pagePicture;
+  QSize paperSize;
+  QRectF brect;
+  Renderer *BACKEND;
+};
+
+#endif // LUMINA_PDF_GRAPHICSITEMS_H

--- a/src-qt5/desktop-utils/lumina-pdf/link.h
+++ b/src-qt5/desktop-utils/lumina-pdf/link.h
@@ -1,0 +1,20 @@
+#ifndef LUMINA_PDF_LINK_H
+#define LUMINA_PDF_LINK_H
+
+namespace LuminaPDF {
+
+class Link {
+public:
+  Link(TextData *_data, Poppler::Link *_link) : data(_data), link(_link) {}
+  ~Link() { delete data; }
+
+  TextData *getData() { return data; }
+  Poppler::Link *getLink() { return link; }
+
+private:
+  TextData *data;
+  Poppler::Link *link;
+};
+
+} // namespace LuminaPDF
+#endif // LUMINA_PDF_LINK_H

--- a/src-qt5/desktop-utils/lumina-pdf/lrucache.h
+++ b/src-qt5/desktop-utils/lumina-pdf/lrucache.h
@@ -1,0 +1,55 @@
+#ifndef LUMINA_PDF_LRUCACHE_H
+#define LUMINA_PDF_LRUCACHE_H
+
+#include <list>
+#include <optional>
+#include <tuple>
+#include <unordered_map>
+
+namespace LuminaPDF {
+template <class Value, class Key = int> class LRUCache {
+public:
+  LRUCache() = default;
+  ~LRUCache() = default;
+
+  void setCacheSize(size_t _max) {
+    max = _max;
+    hashmap.reserve(max);
+    return;
+  }
+
+  std::optional<Value> get(const Key k) {
+    auto itr = hashmap.find(k);
+
+    if (itr == hashmap.end()) {
+      return std::nullopt;
+    }
+
+    Value v = std::get<1>(*std::get<1>(*itr));
+
+    values.erase(std::get<1>(*itr));
+    values.push_front(std::make_tuple(k, v));
+    hashmap[k] = values.begin();
+    return v;
+  }
+
+  void push(const Key k, const Value v) {
+    while (hashmap.size() >= max) {
+      Key _k = std::get<0>(values.back());
+      values.pop_back();
+      hashmap.erase(_k);
+    }
+
+    values.push_front(std::make_tuple(k, v));
+    hashmap[k] = values.begin();
+  }
+
+private:
+  size_t max;
+  std::list<std::tuple<Key, Value>> values;
+  std::unordered_map<Key, typename std::list<std::tuple<Key, Value>>::iterator>
+      hashmap;
+};
+} // namespace LuminaPDF
+
+#endif // LUIMINA_PDF_LRUCACHE_H

--- a/src-qt5/desktop-utils/lumina-pdf/lumina-pdf.pro
+++ b/src-qt5/desktop-utils/lumina-pdf/lumina-pdf.pro
@@ -4,10 +4,12 @@ QT       *= core gui
 greaterThan(QT_MAJOR_VERSION, 4): QT *= widgets concurrent
 
 
+CONFIG += c++1z
 TARGET = lumina-pdf
 TEMPLATE = app
 
 QT += printsupport
+QMAKE_CXXFLAGS += -std=c++17
 
 target.path = $${L_BINDIR}
 
@@ -32,7 +34,11 @@ HEADERS  += mainUI.h \
     Bookmark.h \
     BookmarkMenu.h \
     Annotation.h \
-    Widget.h
+    Widget.h \
+    link.h \
+    drawablepage.h \
+    graphicsitems.h \
+    lrucache.h
 
 FORMS += mainUI.ui \
          PropDialog.ui \

--- a/src-qt5/desktop-utils/lumina-pdf/lumina-pdf.pro.user
+++ b/src-qt5/desktop-utils/lumina-pdf/lumina-pdf.pro.user
@@ -1,0 +1,336 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorProject>
+<!-- Written by QtCreator 4.6.2, 2018-12-18T10:40:29. -->
+<qtcreator>
+ <data>
+  <variable>EnvironmentId</variable>
+  <value type="QByteArray">{a31e5426-3d97-4976-9bd7-91bf95bc2068}</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.ActiveTarget</variable>
+  <value type="int">0</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.EditorSettings</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
+   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
+   <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
+    <value type="QString" key="language">Cpp</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">CppGlobal</value>
+    </valuemap>
+   </valuemap>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.1">
+    <value type="QString" key="language">QmlJS</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
+    </valuemap>
+   </valuemap>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
+   <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
+   <value type="int" key="EditorConfiguration.IndentSize">4</value>
+   <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="int" key="EditorConfiguration.MarginColumn">80</value>
+   <value type="bool" key="EditorConfiguration.MouseHiding">true</value>
+   <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
+   <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
+   <value type="bool" key="EditorConfiguration.ShowMargin">false</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="bool" key="EditorConfiguration.SmartSelectionChanging">true</value>
+   <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
+   <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
+   <value type="int" key="EditorConfiguration.TabSize">8</value>
+   <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
+   <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
+   <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
+   <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap"/>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Target.0</variable>
+  <valuemap type="QVariantMap">
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{83c8fadd-db89-4dca-93ae-73230e72a3be}</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
+   <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/joe/lumina/lumina/src-qt5/desktop-utils/build-lumina-pdf-Desktop-Debug</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">true</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">false</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
+    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/joe/lumina/lumina/src-qt5/desktop-utils/build-lumina-pdf-Desktop-Release</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">false</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">true</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
+    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/joe/lumina/lumina/src-qt5/desktop-utils/build-lumina-pdf-Desktop-Profile</value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">true</value>
+      <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">true</value>
+      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">true</value>
+     </valuemap>
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments"></value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
+    </valuemap>
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
+     <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
+      <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
+      <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.AutomaticallyAddedMakeArguments">
+       <value type="QString">-w</value>
+       <value type="QString">-r</value>
+      </valuelist>
+      <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeArguments">clean</value>
+      <value type="QString" key="Qt4ProjectManager.MakeStep.MakeCommand"></value>
+     </valuemap>
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
+    <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Profile</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Profile</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
+    <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
+    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
+    <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
+     <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
+    </valuemap>
+    <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy Configuration</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.PluginSettings"/>
+   <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
+    <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
+    <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
+    <value type="QString" key="Analyzer.QmlProfiler.LastTraceFile"></value>
+    <value type="bool" key="Analyzer.QmlProfiler.Settings.UseGlobalSettings">true</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.AddedSuppressionFiles"/>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectBusEvents">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.CollectSystime">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableBranchSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableCacheSim">false</value>
+    <value type="bool" key="Analyzer.Valgrind.Callgrind.EnableEventToolTips">true</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
+    <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
+    <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
+    <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
+    <value type="int" key="Analyzer.Valgrind.SelfModifyingCodeDetection">1</value>
+    <value type="bool" key="Analyzer.Valgrind.Settings.UseGlobalSettings">true</value>
+    <value type="bool" key="Analyzer.Valgrind.ShowReachable">false</value>
+    <value type="bool" key="Analyzer.Valgrind.TrackOrigins">true</value>
+    <value type="QString" key="Analyzer.Valgrind.ValgrindExecutable">valgrind</value>
+    <valuelist type="QVariantList" key="Analyzer.Valgrind.VisibleErrorKinds">
+     <value type="int">0</value>
+     <value type="int">1</value>
+     <value type="int">2</value>
+     <value type="int">3</value>
+     <value type="int">4</value>
+     <value type="int">5</value>
+     <value type="int">6</value>
+     <value type="int">7</value>
+     <value type="int">8</value>
+     <value type="int">9</value>
+     <value type="int">10</value>
+     <value type="int">11</value>
+     <value type="int">12</value>
+     <value type="int">13</value>
+     <value type="int">14</value>
+    </valuelist>
+    <value type="int" key="PE.EnvironmentAspect.Base">2</value>
+    <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">lumina-pdf</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/joe/lumina/lumina/src-qt5/desktop-utils/lumina-pdf/lumina-pdf.pro</value>
+    <value type="bool" key="QmakeProjectManager.QmakeRunConfiguration.UseLibrarySearchPath">true</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.CommandLineArguments"></value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">lumina-pdf.pro</value>
+    <value type="bool" key="Qt4ProjectManager.Qt4RunConfiguration.UseDyldImageSuffix">false</value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory"></value>
+    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.UserWorkingDirectory.default">/home/joe/lumina/lumina/src-qt5/desktop-utils/build-lumina-pdf-Desktop-Debug</value>
+    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
+    <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
+   </valuemap>
+   <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.TargetCount</variable>
+  <value type="int">1</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
+  <value type="int">18</value>
+ </data>
+ <data>
+  <variable>Version</variable>
+  <value type="int">18</value>
+ </data>
+</qtcreator>

--- a/src-qt5/desktop-utils/lumina-pdf/main.cpp
+++ b/src-qt5/desktop-utils/lumina-pdf/main.cpp
@@ -1,28 +1,31 @@
-#include <QTranslator>
 #include <QApplication>
 #include <QDebug>
 #include <QFile>
+#include <QTranslator>
 
 #include "mainUI.h"
 #include <LUtils.h>
 //#include <LuminaThemes.h>
 
-int main(int argc, char ** argv)
-{
-  //LTHEME::LoadCustomEnvSettings();
-  unsetenv("QT_AUTO_SCREEN_SCALE_FACTOR"); //need pixel-perfect geometries
+int main(int argc, char **argv) {
+  // LTHEME::LoadCustomEnvSettings();
+  unsetenv("QT_AUTO_SCREEN_SCALE_FACTOR"); // need pixel-perfect geometries
   QApplication a(argc, argv);
   LUtils::LoadTranslation(&a, "l-pdf");
 
-  //Read the input variables
+  // Read the input variables
   QString path = "";
-  for(int i=1; i<argc; i++){
-    path = LUtils::PathToAbsolute( argv[i] );
-    if(QFile::exists(path)){ break; } //already found a valid file
+  for (int i = 1; i < argc; i++) {
+    path = LUtils::PathToAbsolute(argv[i]);
+    if (QFile::exists(path)) {
+      break;
+    } // already found a valid file
   }
 
   MainUI w;
-  if(!path.isEmpty()){  w.loadFile(path); }
+  if (!path.isEmpty()) {
+    w.loadFile(path);
+  }
   w.show();
   int retCode = a.exec();
   return retCode;

--- a/src-qt5/desktop-utils/lumina-pdf/mainUI.cpp
+++ b/src-qt5/desktop-utils/lumina-pdf/mainUI.cpp
@@ -7,30 +7,30 @@
 #include "mainUI.h"
 #include "ui_mainUI.h"
 
-#include <QPainter>
-#include <QImage>
-#include <QSize>
-#include <QFileDialog>
-#include <QInputDialog>
-#include <QDebug>
 #include <QApplication>
+#include <QDebug>
+#include <QFileDialog>
+#include <QImage>
+#include <QInputDialog>
+#include <QPainter>
 #include <QScreen>
-#include <QtConcurrent>
+#include <QSize>
 #include <QSplitter>
+#include <QtConcurrent>
 
-#include <LuminaXDG.h>
 #include "PrintWidget.h"
+#include <LuminaXDG.h>
 
-MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()){
+MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
   ui->setupUi(this);
-  //this->setWindowTitle(tr("Lumina PDF Viewer"));
-  this->setWindowIcon( LXDG::findIcon("application-pdf","unknown"));
+  // this->setWindowTitle(tr("Lumina PDF Viewer"));
+  this->setWindowIcon(LXDG::findIcon("application-pdf", "unknown"));
   presentationLabel = 0;
   CurrentPage = 1;
   lastdir = QDir::homePath();
   BACKEND = new Renderer();
 
-  //Create the interface widgets
+  // Create the interface widgets
   PROPDIALOG = new PropDialog(BACKEND);
   BOOKMARKS = new BookmarkMenu(BACKEND, ui->splitter);
   BOOKMARKS->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -40,106 +40,158 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()){
   ui->splitter->setCollapsible(0, true);
   ui->splitter->setCollapsible(1, false);
   clockTimer = new QTimer(this);
-    clockTimer->setInterval(1000); //1-second updates to clock
-    connect(clockTimer, SIGNAL(timeout()), this, SLOT(updateClock()) );
+  clockTimer->setInterval(1000); // 1-second updates to clock
+  connect(clockTimer, SIGNAL(timeout()), this, SLOT(updateClock()));
   label_clock = new QLabel(this);
-    label_clock->setAlignment(Qt::AlignCenter );
-    label_clock->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    label_clock->setStyleSheet("QLabel{color: palette(highlight-text); background-color: palette(highlight); border-radius: 5px; }");
+  label_clock->setAlignment(Qt::AlignCenter);
+  label_clock->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+  label_clock->setStyleSheet(
+      "QLabel{color: palette(highlight-text); background-color: "
+      "palette(highlight); border-radius: 5px; }");
   label_page = new QLabel(this);
-    label_page->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    label_page->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
+  label_page->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+  label_page->setSizePolicy(QSizePolicy::MinimumExpanding,
+                            QSizePolicy::Preferred);
 
   contextMenu = new QMenu(this);
-    connect(contextMenu, SIGNAL(aboutToShow()), this, SLOT(updateContextMenu()));
+  QObject::connect(contextMenu, SIGNAL(aboutToShow()), this,
+                   SLOT(updateContextMenu()));
 
-  connect(WIDGET, SIGNAL(customContextMenuRequested(const QPoint&)),this, SLOT(showContextMenu(const QPoint&)) );
-  connect(WIDGET, SIGNAL(currentPageChanged()), this, SLOT(updatePageNumber()) );
-  connect(BACKEND, SIGNAL(PageLoaded(int)), this, SLOT(slotPageLoaded(int)) );
-	connect(BACKEND, SIGNAL(reloadPages(int)), this, SLOT(startLoadingPages(int)));
-	connect(BACKEND, SIGNAL(goToPosition(int, float, float)), WIDGET, SLOT(goToPosition(int, float, float)));
-  connect(ui->splitter, &QSplitter::splitterMoved, this, [=]() {
-    double percent = qBound(0.0, (ui->splitter->sizes().first()/(double)this->width())*100.0, 33.3); ui->splitter->setSizes( QList<int>() << this->width()*(percent/100.0) << this->width() * ((100.0-percent)/100.0)); });
+  QObject::connect(WIDGET, SIGNAL(customContextMenuRequested(const QPoint &)),
+                   this, SLOT(showContextMenu(const QPoint &)));
+  QObject::connect(WIDGET, SIGNAL(currentPageChanged()), this,
+                   SLOT(updatePageNumber()));
+  QObject::connect(BACKEND, SIGNAL(PageLoaded()), this, SLOT(slotPageLoaded()));
+  QObject::connect(BACKEND, SIGNAL(SetProgress(int)), this,
+                   SLOT(slotSetProgress(int)));
+  QObject::connect(BACKEND, SIGNAL(reloadPages(int)), this,
+                   SLOT(startLoadingPages(int)));
+  QObject::connect(BACKEND, SIGNAL(goToPosition(int, float, float)), WIDGET,
+                   SLOT(goToPosition(int, float, float)));
+  QObject::connect(ui->splitter, &QSplitter::splitterMoved, this, [=]() {
+    double percent = qBound(
+        0.0, (ui->splitter->sizes().first() / (double)this->width()) * 100.0,
+        33.3);
+    ui->splitter->setSizes(QList<int>()
+                           << this->width() * (percent / 100.0)
+                           << this->width() * ((100.0 - percent) / 100.0));
+  });
 
   PrintDLG = new QPrintDialog(this);
-  connect(PrintDLG, SIGNAL(accepted(QPrinter*)), this, SLOT(paintToPrinter(QPrinter*)) );
-  //connect(ui->menuStart_Presentation, SIGNAL(triggered(QAction*)), this, SLOT(slotStartPresentation(QAction*)) );
+  QObject::connect(PrintDLG, SIGNAL(accepted(QPrinter *)), this,
+                   SLOT(paintToPrinter(QPrinter *)));
+  // connect(ui->menuStart_Presentation, SIGNAL(triggered(QAction*)), this,
+  // SLOT(slotStartPresentation(QAction*)) );
 
-  //Create the other interface widgets
+  // Create the other interface widgets
   progress = new QProgressBar(this);
-    progress->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    progress->setFormat("%v/%m (%p%)"); // [current]/[total]
+  progress->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+  progress->setFormat("%v/%m (%p%)"); // [current]/[total]
   progAct = ui->toolBar->addWidget(progress);
-    progAct->setVisible(false);
+  progAct->setVisible(false);
   clockAct = ui->toolBar->addWidget(label_clock);
-    clockAct->setVisible(false);
+  clockAct->setVisible(false);
   pageAct = ui->toolBar->addWidget(label_page);
-    pageAct->setVisible(false);
+  pageAct->setVisible(false);
 
-  //Put the various actions into logical groups
+  // Put the various actions into logical groups
   QActionGroup *tmp = new QActionGroup(this);
-    tmp->setExclusive(true);
-    tmp->addAction(ui->actionFit_Width);
-    tmp->addAction(ui->actionFit_Page);
+  tmp->setExclusive(true);
+  tmp->addAction(ui->actionFit_Width);
+  tmp->addAction(ui->actionFit_Page);
   ui->actionFit_Page->setChecked(true);
 
   tmp = new QActionGroup(this);
-    tmp->setExclusive(true);
-    tmp->addAction(ui->actionSingle_Page);
-    tmp->addAction(ui->actionDual_Pages);
-    tmp->addAction(ui->actionAll_Pages);
+  tmp->setExclusive(true);
+  tmp->addAction(ui->actionSingle_Page);
+  tmp->addAction(ui->actionDual_Pages);
+  tmp->addAction(ui->actionAll_Pages);
   ui->actionSingle_Page->setChecked(true);
 
-  //Connect up the buttons
-  connect(ui->actionClose, SIGNAL(triggered()), this, SLOT(close()) );
-  connect(ui->actionPrint, SIGNAL(triggered()), PrintDLG, SLOT(open()) );
-  connect(ui->actionFit_Width, SIGNAL(triggered()), WIDGET, SLOT(fitToWidth()) );
-  connect(ui->actionFit_Page, SIGNAL(triggered()), WIDGET, SLOT(fitView()) );
-  connect(ui->actionOpen_PDF, SIGNAL(triggered()), this, SLOT(OpenNewFile()) );
-  connect(ui->actionSingle_Page, SIGNAL(triggered()), WIDGET, SLOT(setSinglePageViewMode()) );
-  connect(ui->actionDual_Pages, SIGNAL(triggered()), WIDGET, SLOT(setFacingPagesViewMode()) );
-  connect(ui->actionAll_Pages, SIGNAL(triggered()), WIDGET, SLOT(setAllPagesViewMode()) );
-  //connect(ui->actionScroll_Mode,  &QAction::triggered, this, [&] { this->setScroll(true); });
-  //connect(ui->actionSelect_Mode, &QAction::triggered, this, [&] { this->setScroll(false); });
-  connect(ui->actionZoom_In,  &QAction::triggered, WIDGET, [&] { WIDGET->zoomIn(1.2);  });
-  connect(ui->actionZoom_Out, &QAction::triggered, WIDGET, [&] { WIDGET->zoomOut(1.2); });
-  connect(ui->actionRotate_Counterclockwise, &QAction::triggered, this, [&] { if(results.size() != 0) { foreach(TextData *x, results) { x->highlighted(false); } } BACKEND->setDegrees(-90); });
-  connect(ui->actionRotate_Clockwise, &QAction::triggered, this, [&] { if(results.size() != 0) { foreach(TextData *x, results) { x->highlighted(false); } } BACKEND->setDegrees(90); });
-  connect(ui->actionZoom_In_2,  &QAction::triggered, WIDGET, [&] { WIDGET->zoomIn(1.2);  });
-  connect(ui->actionZoom_Out_2, &QAction::triggered, WIDGET, [&] { WIDGET->zoomOut(1.2); });
-  connect(ui->actionFirst_Page, SIGNAL(triggered()), this, SLOT(firstPage()) );
-  connect(ui->actionPrevious_Page, SIGNAL(triggered()), this, SLOT(prevPage()) );
-  connect(ui->actionNext_Page, SIGNAL(triggered()), this, SLOT(nextPage()) );
-  connect(ui->actionLast_Page, SIGNAL(triggered()), this, SLOT(lastPage()) );
-  connect(ui->actionProperties, &QAction::triggered, WIDGET, [&] { PROPDIALOG->show(); });
-  connect(BACKEND, &Renderer::OrigSize, this, [&](QSizeF _pageSize) { pageSize = _pageSize; });
-  connect(ui->actionFind, &QAction::triggered, this, [&] {
-    if(ui->findGroup->isVisible()) {
+  // Connect up the buttons
+  QObject::connect(ui->actionClose, SIGNAL(triggered()), this, SLOT(close()));
+  QObject::connect(ui->actionPrint, SIGNAL(triggered()), PrintDLG,
+                   SLOT(open()));
+  QObject::connect(ui->actionFit_Width, SIGNAL(triggered()), WIDGET,
+                   SLOT(fitToWidth()));
+  QObject::connect(ui->actionFit_Page, SIGNAL(triggered()), WIDGET,
+                   SLOT(fitView()));
+  QObject::connect(ui->actionOpen_PDF, SIGNAL(triggered()), this,
+                   SLOT(OpenNewFile()));
+  QObject::connect(ui->actionSingle_Page, SIGNAL(triggered()), WIDGET,
+                   SLOT(setSinglePageViewMode()));
+  QObject::connect(ui->actionDual_Pages, SIGNAL(triggered()), WIDGET,
+                   SLOT(setFacingPagesViewMode()));
+  QObject::connect(ui->actionAll_Pages, SIGNAL(triggered()), WIDGET,
+                   SLOT(setAllPagesViewMode()));
+  // connect(ui->actionScroll_Mode,  &QAction::triggered, this, [&] {
+  // this->setScroll(true); }); connect(ui->actionSelect_Mode,
+  // &QAction::triggered, this, [&] { this->setScroll(false); });
+  QObject::connect(ui->actionZoom_In, &QAction::triggered, WIDGET,
+                   [&] { WIDGET->zoomIn(1.2); });
+  QObject::connect(ui->actionZoom_Out, &QAction::triggered, WIDGET,
+                   [&] { WIDGET->zoomOut(1.2); });
+  QObject::connect(ui->actionRotate_Counterclockwise, &QAction::triggered, this,
+                   [&] {
+                     if (results.size() != 0) {
+                       foreach (TextData *x, results) { x->highlighted(false); }
+                     }
+                     BACKEND->setDegrees(-90);
+                   });
+  QObject::connect(ui->actionRotate_Clockwise, &QAction::triggered, this, [&] {
+    if (results.size() != 0) {
+      foreach (TextData *x, results) { x->highlighted(false); }
+    }
+    BACKEND->setDegrees(90);
+  });
+  QObject::connect(ui->actionZoom_In_2, &QAction::triggered, WIDGET,
+                   [&] { WIDGET->zoomIn(1.2); });
+  QObject::connect(ui->actionZoom_Out_2, &QAction::triggered, WIDGET,
+                   [&] { WIDGET->zoomOut(1.2); });
+  QObject::connect(ui->actionFirst_Page, SIGNAL(triggered()), this,
+                   SLOT(firstPage()));
+  QObject::connect(ui->actionPrevious_Page, SIGNAL(triggered()), this,
+                   SLOT(prevPage()));
+  QObject::connect(ui->actionNext_Page, SIGNAL(triggered()), this,
+                   SLOT(nextPage()));
+  QObject::connect(ui->actionLast_Page, SIGNAL(triggered()), this,
+                   SLOT(lastPage()));
+  QObject::connect(ui->actionProperties, &QAction::triggered, WIDGET,
+                   [&] { PROPDIALOG->show(); });
+  QObject::connect(BACKEND, &Renderer::OrigSize, this,
+                   [&](QSizeF _pageSize) { pageSize = _pageSize; });
+  QObject::connect(ui->actionFind, &QAction::triggered, this, [&] {
+    if (ui->findGroup->isVisible()) {
       ui->findGroup->setVisible(false);
       this->setFocus();
-    }else{
+    } else {
       ui->findGroup->setVisible(true);
       ui->findGroup->setFocus();
     }
   });
-  connect(ui->actionFind_Next,  &QAction::triggered, this,
-    [&] { find(ui->textEdit->text(), true); });
-  connect(ui->actionFind_Previous,  &QAction::triggered, this,
-    [&] { find(ui->textEdit->text(), false); });
-  connect(ui->findNextB,  &QPushButton::clicked, this,
-    [&] { find(ui->textEdit->text(), true); });
-  connect(ui->findPrevB,  &QPushButton::clicked, this,
-    [&] { find(ui->textEdit->text(), false); });
-  connect(ui->matchCase, &QPushButton::clicked, this,
-    [&] (bool value) { this->matchCase = value; });
-  connect(ui->closeFind, &QPushButton::clicked, this,
-    [&] { ui->findGroup->setVisible(false); this->setFocus(); });
-  connect(ui->actionClearHighlights,  &QAction::triggered, WIDGET,
-    [&] { WIDGET->updatePreview(); });
-  connect(ui->actionBookmarks, &QAction::triggered, this, [=] () { ui->splitter->setSizes( QList<int>() << this->width()/4 << 3*this->width()/4); });
+  QObject::connect(ui->actionFind_Next, &QAction::triggered, this,
+                   [&] { find(ui->textEdit->text(), true); });
+  QObject::connect(ui->actionFind_Previous, &QAction::triggered, this,
+                   [&] { find(ui->textEdit->text(), false); });
+  QObject::connect(ui->findNextB, &QPushButton::clicked, this,
+                   [&] { find(ui->textEdit->text(), true); });
+  QObject::connect(ui->findPrevB, &QPushButton::clicked, this,
+                   [&] { find(ui->textEdit->text(), false); });
+  QObject::connect(ui->matchCase, &QPushButton::clicked, this,
+                   [&](bool value) { this->matchCase = value; });
+  QObject::connect(ui->closeFind, &QPushButton::clicked, this, [&] {
+    ui->findGroup->setVisible(false);
+    this->setFocus();
+  });
+  QObject::connect(ui->actionClearHighlights, &QAction::triggered, WIDGET,
+                   [&] { WIDGET->updatePreview(); });
+  QObject::connect(ui->actionBookmarks, &QAction::triggered, this, [=]() {
+    ui->splitter->setSizes(QList<int>()
+                           << this->width() / 4 << 3 * this->width() / 4);
+  });
 
-  //int curP = WIDGET->currentPage()-1; //currentPage reports pages starting at 1
-  //int lastP = numPages-1;
+  // int curP = WIDGET->currentPage()-1; //currentPage reports pages starting at
+  // 1 int lastP = numPages-1;
   ui->actionFirst_Page->setText(tr("First Page"));
   ui->actionPrevious_Page->setText(tr("Previous Page"));
   ui->actionNext_Page->setText(tr("Next Page"));
@@ -150,57 +202,70 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()){
   ui->actionLast_Page->setEnabled(curP!=lastP);*/
 
   ui->actionStart_Here->setText(tr("Start Presentation (current slide)"));
-  connect(ui->actionStart_Here, SIGNAL(triggered()), this, SLOT(startPresentationHere()) );
+  QObject::connect(ui->actionStart_Here, SIGNAL(triggered()), this,
+                   SLOT(startPresentationHere()));
   ui->actionStart_Begin->setText(tr("Start Presentation (at beginning)"));
-  connect(ui->actionStart_Begin, SIGNAL(triggered()), this, SLOT(startPresentationBeginning()) );
+  QObject::connect(ui->actionStart_Begin, SIGNAL(triggered()), this,
+                   SLOT(startPresentationBeginning()));
   ui->actionStop_Presentation->setText(tr("Stop Presentation"));
-  connect(ui->actionStop_Presentation, SIGNAL(triggered()), this, SLOT(closePresentation()) );
+  QObject::connect(ui->actionStop_Presentation, SIGNAL(triggered()), this,
+                   SLOT(closePresentation()));
 
-  //Setup all the icons
-  ui->actionPrint->setIcon( LXDG::findIcon("document-print",""));
-  ui->actionClose->setIcon( LXDG::findIcon("window-close",""));
-  ui->actionFit_Width->setIcon(LXDG::findIcon("transform-scale",""));
-  ui->actionFit_Page->setIcon(LXDG::findIcon("zoom-fit-best",""));
-  ui->actionOpen_PDF->setIcon(LXDG::findIcon("document-open",""));
-  ui->actionSingle_Page->setIcon(LXDG::findIcon("view-split-top-bottom", "format-view-agenda"));
-  ui->actionDual_Pages->setIcon(LXDG::findIcon("view-split-left-right", "format-view-grid-small"));
-  ui->actionAll_Pages->setIcon(LXDG::findIcon("view-grid", "format-view-grid-large"));
-  ui->actionScroll_Mode->setIcon(LXDG::findIcon("cursor-pointer",""));
-  ui->actionSelect_Mode->setIcon(LXDG::findIcon("cursor-text",""));
-  ui->actionZoom_In->setIcon(LXDG::findIcon("zoom-in",""));
-  ui->actionZoom_Out->setIcon(LXDG::findIcon("zoom-out",""));
-  ui->actionZoom_In_2->setIcon(LXDG::findIcon("zoom-in",""));
-  ui->actionZoom_Out_2->setIcon(LXDG::findIcon("zoom-out",""));
-  ui->actionRotate_Counterclockwise->setIcon(LXDG::findIcon("object-rotate-left",""));
-  ui->actionRotate_Clockwise->setIcon(LXDG::findIcon("object-rotate-right",""));
-  ui->actionFirst_Page->setIcon(LXDG::findIcon("go-first",""));
-  ui->actionPrevious_Page->setIcon(LXDG::findIcon("go-previous",""));
-  ui->actionNext_Page->setIcon(LXDG::findIcon("go-next",""));
-  ui->actionLast_Page->setIcon(LXDG::findIcon("go-last",""));
-  ui->actionStart_Here->setIcon(LXDG::findIcon("video-display","media-playback-start-circled"));
-  ui->actionStart_Begin->setIcon(LXDG::findIcon("view-presentation","presentation-play"));
-  ui->actionStop_Presentation->setIcon(LXDG::findIcon("media-playback-stop", "media-playback-stop-circled"));
-  ui->actionBookmarks->setIcon(LXDG::findIcon("bookmark-new",""));
-  ui->actionFind->setIcon(LXDG::findIcon("edit-find",""));
-  ui->actionFind_Next->setIcon(LXDG::findIcon("go-down-search", "edit-find-next"));
-  ui->actionFind_Previous->setIcon(LXDG::findIcon("go-up-search", "edit-find-prev"));
-  ui->actionProperties->setIcon(LXDG::findIcon("dialog-information",""));
-  ui->actionSettings->setIcon(LXDG::findIcon("document-properties",""));
+  // Setup all the icons
+  ui->actionPrint->setIcon(LXDG::findIcon("document-print", ""));
+  ui->actionClose->setIcon(LXDG::findIcon("window-close", ""));
+  ui->actionFit_Width->setIcon(LXDG::findIcon("transform-scale", ""));
+  ui->actionFit_Page->setIcon(LXDG::findIcon("zoom-fit-best", ""));
+  ui->actionOpen_PDF->setIcon(LXDG::findIcon("document-open", ""));
+  ui->actionSingle_Page->setIcon(
+      LXDG::findIcon("view-split-top-bottom", "format-view-agenda"));
+  ui->actionDual_Pages->setIcon(
+      LXDG::findIcon("view-split-left-right", "format-view-grid-small"));
+  ui->actionAll_Pages->setIcon(
+      LXDG::findIcon("view-grid", "format-view-grid-large"));
+  ui->actionScroll_Mode->setIcon(LXDG::findIcon("cursor-pointer", ""));
+  ui->actionSelect_Mode->setIcon(LXDG::findIcon("cursor-text", ""));
+  ui->actionZoom_In->setIcon(LXDG::findIcon("zoom-in", ""));
+  ui->actionZoom_Out->setIcon(LXDG::findIcon("zoom-out", ""));
+  ui->actionZoom_In_2->setIcon(LXDG::findIcon("zoom-in", ""));
+  ui->actionZoom_Out_2->setIcon(LXDG::findIcon("zoom-out", ""));
+  ui->actionRotate_Counterclockwise->setIcon(
+      LXDG::findIcon("object-rotate-left", ""));
+  ui->actionRotate_Clockwise->setIcon(
+      LXDG::findIcon("object-rotate-right", ""));
+  ui->actionFirst_Page->setIcon(LXDG::findIcon("go-first", ""));
+  ui->actionPrevious_Page->setIcon(LXDG::findIcon("go-previous", ""));
+  ui->actionNext_Page->setIcon(LXDG::findIcon("go-next", ""));
+  ui->actionLast_Page->setIcon(LXDG::findIcon("go-last", ""));
+  ui->actionStart_Here->setIcon(
+      LXDG::findIcon("video-display", "media-playback-start-circled"));
+  ui->actionStart_Begin->setIcon(
+      LXDG::findIcon("view-presentation", "presentation-play"));
+  ui->actionStop_Presentation->setIcon(
+      LXDG::findIcon("media-playback-stop", "media-playback-stop-circled"));
+  ui->actionBookmarks->setIcon(LXDG::findIcon("bookmark-new", ""));
+  ui->actionFind->setIcon(LXDG::findIcon("edit-find", ""));
+  ui->actionFind_Next->setIcon(
+      LXDG::findIcon("go-down-search", "edit-find-next"));
+  ui->actionFind_Previous->setIcon(
+      LXDG::findIcon("go-up-search", "edit-find-prev"));
+  ui->actionProperties->setIcon(LXDG::findIcon("dialog-information", ""));
+  ui->actionSettings->setIcon(LXDG::findIcon("document-properties", ""));
   ui->findNextB->setIcon(LXDG::findIcon("go-down-search"));
   ui->findPrevB->setIcon(LXDG::findIcon("go-up-search"));
-  ui->actionClearHighlights->setIcon(LXDG::findIcon("format-text-clear",""));
+  ui->actionClearHighlights->setIcon(LXDG::findIcon("format-text-clear", ""));
   ui->findNextB->setIcon(LXDG::findIcon("go-down-search"));
   ui->matchCase->setIcon(LXDG::findIcon("format-text-italic"));
   ui->closeFind->setIcon(LXDG::findIcon("dialog-close"));
 
-  //Now set the default state of the menu's and actions
+  // Now set the default state of the menu's and actions
   ui->actionStop_Presentation->setEnabled(false);
   ui->actionStart_Here->setEnabled(false);
   ui->actionStart_Begin->setEnabled(false);
 
   ui->findGroup->setVisible(false);
 
-  //TESTING features/functionality
+  // TESTING features/functionality
   bool TESTING = BACKEND->supportsExtraFeatures();
   ui->actionBookmarks->setEnabled(TESTING);
   ui->actionBookmarks->setVisible(TESTING);
@@ -217,87 +282,120 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()){
   ui->actionSelect_Mode->setVisible(false);
 }
 
-MainUI::~MainUI(){
-  if(BOOKMARKS!=0){ BOOKMARKS->deleteLater(); }
-  if(PROPDIALOG!=0) { PROPDIALOG->deleteLater(); }
+MainUI::~MainUI() {
+  if (BOOKMARKS != 0) {
+    BOOKMARKS->deleteLater();
+  }
+  if (PROPDIALOG != 0) {
+    PROPDIALOG->deleteLater();
+  }
   delete BACKEND;
 }
 
-void MainUI::loadFile(QString path){
-  if(!QFile::exists(path) || path.isEmpty() ){ return; }
+void MainUI::loadFile(QString path) {
+  if (!QFile::exists(path) || path.isEmpty()) {
+    return;
+  }
   QString password;
   bool ok = true;
 
-  while( ok && !BACKEND->loadDocument(path, password) && BACKEND->needPassword() ){
-    password = QInputDialog::getText(this, tr("Unlock PDF"), tr("Password:"), QLineEdit::Password, "", &ok);
-    if(!ok){ break; } //cancelled
+  while (ok && !BACKEND->loadDocument(path, password) &&
+         BACKEND->needPassword()) {
+    password = QInputDialog::getText(this, tr("Unlock PDF"), tr("Password:"),
+                                     QLineEdit::Password, "", &ok);
+    if (!ok) {
+      break;
+    } // cancelled
   }
-  //Clear the current display
+  // Clear the current display
 
-	WIDGET->setVisible(false);
+  WIDGET->setVisible(false);
   BOOKMARKS->setVisible(false);
-  //Load the new document info
-  this->setWindowTitle( BACKEND->title());
-  if(BACKEND->needPassword()){ return; } //cancelled;
+  // Load the new document info
+  this->setWindowTitle(BACKEND->title());
+  if (BACKEND->needPassword()) {
+    return;
+  } // cancelled;
   qDebug() << " - Document Setup : start loading pages now";
 
-  //Populate or repopulate the Bookmarks menu and Properties Dialog
-  QTimer::singleShot(10, BOOKMARKS, SLOT(loadBookmarks()) );
-  QTimer::singleShot(10, PROPDIALOG, SLOT(setInformation()) );
-  QTimer::singleShot(50, [&]() { startLoadingPages(0); } );
+  // Populate or repopulate the Bookmarks menu and Properties Dialog
+  QTimer::singleShot(10, BOOKMARKS, SLOT(loadBookmarks()));
+  QTimer::singleShot(10, PROPDIALOG, SLOT(setInformation()));
+  QTimer::singleShot(50, [&]() { startLoadingPages(0); });
 }
 
-QScreen* MainUI::getScreen(bool current, bool &cancelled){
-  //Note: the "cancelled" boolian is actually an output - not an input
-  QList<QScreen*> screens = QApplication::screens();
+QScreen *MainUI::getScreen(bool current, bool &cancelled) {
+  // Note: the "cancelled" boolian is actually an output - not an input
+  QList<QScreen *> screens = QApplication::screens();
   cancelled = false;
-  if(screens.length() ==1){ return screens[0]; } //only one option
-  //Multiple screens available - figure it out
-  if(current){
-    //Just return the screen the window is currently on
-    for(int i=0; i<screens.length(); i++){
-      if(screens[i]->geometry().contains( this->mapToGlobal(this->pos()) )){
+  if (screens.length() == 1) {
+    return screens[0];
+  } // only one option
+  // Multiple screens available - figure it out
+  if (current) {
+    // Just return the screen the window is currently on
+    for (int i = 0; i < screens.length(); i++) {
+      if (screens[i]->geometry().contains(this->mapToGlobal(this->pos()))) {
         return screens[i];
       }
     }
-    //If it gets this far, there was an error and it should just return the primary screen
+    // If it gets this far, there was an error and it should just return the
+    // primary screen
     return QApplication::primaryScreen();
-  }else{
-    //Ask the user to select a screen (for presentations, etc..)
+  } else {
+    // Ask the user to select a screen (for presentations, etc..)
     QStringList names;
-    for(int i=0; i<screens.length(); i++){
-      QString screensize = QString::number(screens[i]->size().width())+"x"+QString::number(screens[i]->size().height());
-       names << QString(tr("%1 (%2)")).arg(screens[i]->name(), screensize);
+    for (int i = 0; i < screens.length(); i++) {
+      QString screensize = QString::number(screens[i]->size().width()) + "x" +
+                           QString::number(screens[i]->size().height());
+      names << QString(tr("%1 (%2)")).arg(screens[i]->name(), screensize);
     }
     bool ok = false;
-    QString sel = QInputDialog::getItem(this, tr("Select Screen"), tr("Screen:"), names, 0, false, &ok);
+    QString sel = QInputDialog::getItem(this, tr("Select Screen"),
+                                        tr("Screen:"), names, 0, false, &ok);
     cancelled = !ok;
-    if(!ok){ return screens[0]; } //cancelled - just return the first one
+    if (!ok) {
+      return screens[0];
+    } // cancelled - just return the first one
     int index = names.indexOf(sel);
-    if(index < 0){ return screens[0]; } //error - should never happen though
-    return screens[index]; //return the selected screen
+    if (index < 0) {
+      return screens[0];
+    }                      // error - should never happen though
+    return screens[index]; // return the selected screen
   }
 }
 
-void MainUI::startPresentation(bool atStart){
-  if(BACKEND->hashSize() == 0){ return; } //just in case
+void MainUI::startPresentation(bool atStart) {
+  if (BACKEND->hashSize() == 0) {
+    qDebug() << "MainUI::startPresentation() called while backend is empty!\n";
+    return;
+  } // just in case
   bool cancelled = false;
-  QScreen *screen = getScreen(false, cancelled); //let the user select which screen to use (if multiples)
-  if(cancelled){ return;}
-  int page = 1;
-  if(!atStart){ page = WIDGET->currentPage(); }
-  //PDPI = QSize(SCALEFACTOR*screen->physicalDotsPerInchX(), SCALEFACTOR*screen->physicalDotsPerInchY());
-  //Now create the full-screen window on the selected screen
-  if(presentationLabel == 0){
-    //Create the label and any special flags for it
-    presentationLabel = new PresentationLabel();
-      presentationLabel->setStyleSheet("background-color: black;");
-      presentationLabel->setAlignment(Qt::AlignCenter);
-      presentationLabel->setContextMenuPolicy(Qt::CustomContextMenu);
-      connect(presentationLabel, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showContextMenu(const QPoint&)) );
-      connect(presentationLabel, SIGNAL(nextSlide()), this, SLOT(nextPage()) );
+  QScreen *screen = getScreen(
+      false,
+      cancelled); // let the user select which screen to use (if multiples)
+  if (cancelled) {
+    return;
   }
-  //Now put the label in the proper location
+  int page = 1;
+  if (!atStart) {
+    page = WIDGET->currentPage();
+  }
+  // PDPI = QSize(SCALEFACTOR*screen->physicalDotsPerInchX(),
+  // SCALEFACTOR*screen->physicalDotsPerInchY()); Now create the full-screen
+  // window on the selected screen
+  if (presentationLabel == 0) {
+    // Create the label and any special flags for it
+    presentationLabel = new PresentationLabel();
+    presentationLabel->setStyleSheet("background-color: black;");
+    presentationLabel->setAlignment(Qt::AlignCenter);
+    presentationLabel->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(presentationLabel,
+            SIGNAL(customContextMenuRequested(const QPoint &)), this,
+            SLOT(showContextMenu(const QPoint &)));
+    connect(presentationLabel, SIGNAL(nextSlide()), this, SLOT(nextPage()));
+  }
+  // Now put the label in the proper location
   presentationLabel->setGeometry(screen->geometry());
   presentationLabel->showFullScreen();
 
@@ -309,42 +407,56 @@ void MainUI::startPresentation(bool atStart){
   clockAct->setVisible(true);
   clockTimer->start();
   QApplication::processEvents();
-  //Now start at the proper page
+  // Now start at the proper page
   ShowPage(page);
-  this->grabKeyboard(); //Grab any keyboard events - even from the presentation window
+  this->grabKeyboard(); // Grab any keyboard events - even from the presentation
+                        // window
 }
 
-void MainUI::ShowPage(int page){
-  //Check for valid document/page
-  //qDebug() << "Load Page:" << page << "/" << BACKEND->numPages() << "Index:" << page;
-  if(page <= 0 || page > BACKEND->numPages() || (page==BACKEND->numPages() && CurrentPage==page) ){
+void MainUI::ShowPage(int page) {
+  // Check for valid document/page
+  // qDebug() << "Load Page:" << page << "/" << BACKEND->numPages() << "Index:"
+  // << page;
+  page = std::max(1, std::min(page, BACKEND->numPages()));
+  if (page == BACKEND->numPages() and CurrentPage == page) {
     endPresentation();
-    return; //invalid - no document loaded or invalid page specified
+    return; // invalid - no document loaded or invalid page specified
   }
-  WIDGET->setCurrentPage(page); //page numbers start at 1 for this widget
-  //Stop here if no presentation currently running
+  WIDGET->setCurrentPage(page); // page numbers start at 1 for this widget
+  // Stop here if no presentation currently running
 
-  if(presentationLabel == 0 || !presentationLabel->isVisible()){ return; }
-  //qDebug() << "Show Page:" << page << "/" << numPages;
+  if (presentationLabel == 0 || !presentationLabel->isVisible()) {
+    WIDGET->updatePreview();
+    return;
+  }
+  // qDebug() << "Show Page:" << page << "/" << numPages;
   CurrentPage = page;
   QImage PAGEIMAGE;
-  if(page<BACKEND->numPages()+1){ PAGEIMAGE = BACKEND->imageHash(page-1); }
+  if (page < BACKEND->numPages() + 1) {
+    PAGEIMAGE = BACKEND->imageHash(page - 1);
+  }
 
-  //Now scale the image according to the user-designations and show it
-  if(!PAGEIMAGE.isNull()){
+  // Now scale the image according to the user-designations and show it
+  if (!PAGEIMAGE.isNull()) {
     QPixmap pix;
-    pix.convertFromImage( PAGEIMAGE.scaled( presentationLabel->size(), Qt::KeepAspectRatio, Qt::SmoothTransformation) );
+    pix.convertFromImage(PAGEIMAGE.scaled(presentationLabel->size(),
+                                          Qt::KeepAspectRatio,
+                                          Qt::SmoothTransformation));
     presentationLabel->setPixmap(pix);
-    presentationLabel->show(); //always make sure it was not hidden
-  }else{
-    //Blank page (useful so there is one blank page after the last slide before stopping the presentation)
+    presentationLabel->show(); // always make sure it was not hidden
+  } else {
+    // Blank page (useful so there is one blank page after the last slide before
+    // stopping the presentation)
     presentationLabel->setPixmap(QPixmap());
   }
 }
 
-void MainUI::endPresentation(){
-  if(presentationLabel==0 || !presentationLabel->isVisible()){ return; } //not in presentation mode
-  presentationLabel->hide(); //just hide this (no need to re-create the label for future presentations)
+void MainUI::endPresentation() {
+  if (presentationLabel == 0 || !presentationLabel->isVisible()) {
+    return;
+  }                          // not in presentation mode
+  presentationLabel->hide(); // just hide this (no need to re-create the label
+                             // for future presentations)
   ui->actionStop_Presentation->setEnabled(false);
   ui->actionStart_Here->setEnabled(true);
   ui->actionStart_Begin->setEnabled(true);
@@ -354,145 +466,170 @@ void MainUI::endPresentation(){
   updatePageNumber();
 }
 
-void MainUI::startLoadingPages(int degrees){
-  //qDebug() <<"Start Loading Pages";
-  //if(BACKEND->hashSize() != 0) { return; } //currently loaded[ing]
+void MainUI::startLoadingPages(int degrees) {
+  // qDebug() <<"Start Loading Pages";
+  // if(BACKEND->hashSize() != 0) { return; } //currently loaded[ing]
   loadingQueue.clear();
-	BACKEND->clearHash();
+  // BACKEND->clearHash();
   WIDGET->setVisible(false);
   BOOKMARKS->setVisible(false);
   progress->setRange(0, BACKEND->numPages());
   progress->setValue(0);
   progAct->setVisible(true);
   pageAct->setVisible(false);
-  //PERFORMANCE NOTES:
-  // Using Poppler to scale the image (adjust dpi value) helps a bit but you take a larger CPU loading hit (and still quite a lot of pixelization)
-  // Using Qt to scale the image (adjust page value) smooths out the image quite a bit without a lot of performance loss (but cannot scale up without pixelization)
-  // The best approach seams to be to increase the DPI a bit, but match that with the same scaling on the page size (smoothing)
+  // PERFORMANCE NOTES:
+  // Using Poppler to scale the image (adjust dpi value) helps a bit but you
+  // take a larger CPU loading hit (and still quite a lot of pixelization) Using
+  // Qt to scale the image (adjust page value) smooths out the image quite a bit
+  // without a lot of performance loss (but cannot scale up without
+  // pixelization) The best approach seams to be to increase the DPI a bit, but
+  // match that with the same scaling on the page size (smoothing)
 
-  QSize DPI(250,250); //print-quality (some printers even go to 600 DPI nowdays)
+  QSize DPI(250,
+            250); // print-quality (some printers even go to 600 DPI nowdays)
 
   /*qDebug() << "Screen Resolutions:";
   QList<QScreen*> screens = QApplication::screens();
   for(int i=0; i<screens.length(); i++){
-    qDebug() << screens[i]->name() << screens[i]->logicalDotsPerInchX() << screens[i]->logicalDotsPerInchY();
+    qDebug() << screens[i]->name() << screens[i]->logicalDotsPerInchX() <<
+  screens[i]->logicalDotsPerInchY();
   }*/
-
-  for(int i=0; i<BACKEND->numPages(); i++){
-    //qDebug() << " - Kickoff page load:" << i;
-    if(BACKEND->loadMultiThread()) {
+  int n = BACKEND->numPages() + 1;
+  for (int i = 1; i < n; i++) {
+    // qDebug() << " - Kickoff page load:" << i;
+    if (BACKEND->loadMultiThread()) {
       QtConcurrent::run(BACKEND, &Renderer::renderPage, i, DPI, degrees);
-    }else{
+    } else {
       BACKEND->renderPage(i, DPI, degrees);
-      if(i % 50 == 0){ QCoreApplication::processEvents(); }
+      if (i % 50 == 0) {
+        QCoreApplication::processEvents();
+      }
     }
   }
-  //qDebug() << "Finish page loading kickoff";
+  // qDebug() << "Finish page loading kickoff";
 }
 
-void MainUI::slotPageLoaded(int page){
-  loadingQueue.push_back(page);
-  int finished = loadingQueue.size();
-  //qDebug() << "Page Loaded:" << page << finished;
-  if(finished == BACKEND->numPages()){
-    progAct->setVisible(false);
-    WIDGET->setVisible(true);
-    BOOKMARKS->setVisible(true);
-    ui->splitter->setSizes(QList<int>() << 0 << this->width());
-    WIDGET->setCurrentPage(1);
-    ui->actionStop_Presentation->setEnabled(false);
-    ui->actionStart_Here->setEnabled(true);
-    ui->actionStart_Begin->setEnabled(true);
-    pageAct->setVisible(true);
-    PROPDIALOG->setSize(pageSize);
-    qDebug() << " - Document Setup: All pages loaded";
-    QTimer::singleShot(10, WIDGET, SLOT(updatePreview())); //start loading the file preview
-  }else{
-    progress->setValue(finished);
+void MainUI::slotSetProgress(int finished) { progress->setValue(finished); }
+
+void MainUI::slotPageLoaded() {
+  // loadingQueue.push_back(page);
+  // int finished = loadingQueue.size();
+  // qDebug() << "Page Loaded:" << page << finished;
+  // if (finished == BACKEND->numPages()) {
+  progAct->setVisible(false);
+  WIDGET->setVisible(true);
+  BOOKMARKS->setVisible(true);
+  ui->splitter->setSizes(QList<int>() << 0 << this->width());
+  WIDGET->setCurrentPage(1);
+  ui->actionStop_Presentation->setEnabled(false);
+  ui->actionStart_Here->setEnabled(true);
+  ui->actionStart_Begin->setEnabled(true);
+  pageAct->setVisible(true);
+  PROPDIALOG->setSize(pageSize);
+  qDebug() << " - Document Setup: All pages loaded";
+  // QTimer::singleShot(10, WIDGET,
+  //                   SLOT(updatePreview())); // start loading the file preview
+  WIDGET->updatePreview();
+}
+
+void MainUI::paintToPrinter(QPrinter *PRINTER) {
+  if (BACKEND->hashSize() != BACKEND->numPages()) {
+    return;
   }
-}
-
-void MainUI::paintToPrinter(QPrinter *PRINTER){
-  if(BACKEND->hashSize() != BACKEND->numPages()){ return; }
-  //qDebug() << "paintToPrinter";
+  // qDebug() << "paintToPrinter";
   int pages = BACKEND->numPages();
   int firstpage = 0;
   int copies = PRINTER->copyCount();
   bool collate = PRINTER->collateCopies();
-  bool reverse = (PRINTER->pageOrder()==QPrinter::LastPageFirst);
-  //qDebug() << "PRINTER DPI:" << PRINTER->resolution() << PRINTER->supportedResolutions();
-  if(PRINTER->resolution() < 300){
-    //Try to get 300 DPI resolution at least
+  bool reverse = (PRINTER->pageOrder() == QPrinter::LastPageFirst);
+  // qDebug() << "PRINTER DPI:" << PRINTER->resolution() <<
+  // PRINTER->supportedResolutions();
+  if (PRINTER->resolution() < 300) {
+    // Try to get 300 DPI resolution at least
     PRINTER->setResolution(300);
     qDebug() << "Trying to change print resolution to 300 minimum";
-    qDebug() << "  -- Resolutions listed as supported:" << PRINTER->supportedResolutions();
+    qDebug() << "  -- Resolutions listed as supported:"
+             << PRINTER->supportedResolutions();
   }
-  //bool duplex = (PRINTER->duplex()!=QPrinter::DuplexNone);
-  //Determine the first page that needs to be printed, and the range
-  if((PRINTER->fromPage() != PRINTER->toPage() || PRINTER->fromPage()!=0 ) && PRINTER->printRange()==QPrinter::PageRange ){
+  // bool duplex = (PRINTER->duplex()!=QPrinter::DuplexNone);
+  // Determine the first page that needs to be printed, and the range
+  if ((PRINTER->fromPage() != PRINTER->toPage() || PRINTER->fromPage() != 0) &&
+      PRINTER->printRange() == QPrinter::PageRange) {
     firstpage = PRINTER->fromPage() - 1;
     pages = PRINTER->toPage();
   }
-  qDebug() << "Start Printing PDF: Pages" << PRINTER->fromPage() <<" to "<< PRINTER->toPage()<< " Copies:" << copies << "  collate:" << collate << " Reverse Order:" << reverse;
+  qDebug() << "Start Printing PDF: Pages" << PRINTER->fromPage() << " to "
+           << PRINTER->toPage() << " Copies:" << copies
+           << "  collate:" << collate << " Reverse Order:" << reverse;
   QList<int> pageCount;
-  //Assemble the page order/count based on printer settings
-  for(int i=firstpage; i<pages; i++){
-    //Make sure even/odd pages are not selected as desired
-    //Qt 5.7.1 does not seem to have even/odd page selections - 8/11/2017
-    pageCount << i; //add this page to the list
-    //QT 5.9+ : Do not need to manually stack "copies". Already handled internally
-    //for(int c=1; c<copies && !collate; c++){ pageCount << i; } //add any copies of this page as needed
+  // Assemble the page order/count based on printer settings
+  for (int i = firstpage; i < pages; i++) {
+    // Make sure even/odd pages are not selected as desired
+    // Qt 5.7.1 does not seem to have even/odd page selections - 8/11/2017
+    pageCount << i; // add this page to the list
+    // QT 5.9+ : Do not need to manually stack "copies". Already handled
+    // internally for(int c=1; c<copies && !collate; c++){ pageCount << i; }
+    // //add any copies of this page as needed
   }
-  //qDebug() << "Got Page Range:" << pageCount;
-  //QT 5.9+ : Do not need to manually reverse the pages (already handled internally)
-  if(reverse) {
-    //Need to reverse the order of the list
+  // qDebug() << "Got Page Range:" << pageCount;
+  // QT 5.9+ : Do not need to manually reverse the pages (already handled
+  // internally)
+  if (reverse) {
+    // Need to reverse the order of the list
     QList<int> tmp = pageCount;
     pageCount.clear();
-    for(int i=tmp.length()-1; i>=0; i--){ pageCount << tmp[i]; }
-    //qDebug() << " - reversed:" << pageCount;
+    for (int i = tmp.length() - 1; i >= 0; i--) {
+      pageCount << tmp[i];
+    }
+    // qDebug() << " - reversed:" << pageCount;
   }
-  //QT 5.9+ : Do not need to manually stack "copies". Already handled internally;
+  // QT 5.9+ : Do not need to manually stack "copies". Already handled
+  // internally;
   /*if(collate && copies>0){
     QList<int> orig = pageCount; //original array of pages
     for(int c=1; c<copies; c++){
       pageCount << orig; //add a new copy of the entire page range
     }
   }*/
-  //qDebug() << "Final Page Range:" << pageCount;
-  //Generate the sizing information for the printer
+  // qDebug() << "Final Page Range:" << pageCount;
+  // Generate the sizing information for the printer
   QSize sz(PRINTER->pageRect().width(), PRINTER->pageRect().height());
-  bool landscape = PRINTER->orientation()==QPrinter::Landscape;
-  if(landscape){ sz = QSize(sz.height(), sz.width() ); } //flip the size dimensions as needed
-  //Now send out the pages in the right order/format
+  bool landscape = PRINTER->orientation() == QPrinter::Landscape;
+  if (landscape) {
+    sz = QSize(sz.height(), sz.width());
+  } // flip the size dimensions as needed
+  // Now send out the pages in the right order/format
   QPainter painter(PRINTER);
-    //Ensure all the antialiasing/smoothing options are turned on
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setRenderHint(QPainter::TextAntialiasing);
-    painter.setRenderHint(QPainter::SmoothPixmapTransform);
+  // Ensure all the antialiasing/smoothing options are turned on
+  painter.setRenderHint(QPainter::Antialiasing);
+  painter.setRenderHint(QPainter::TextAntialiasing);
+  painter.setRenderHint(QPainter::SmoothPixmapTransform);
 
   QTransform transF;
   transF.rotate(90);
-  //Show the progress bar
+  // Show the progress bar
   progAct->setVisible(true);
-  progress->setRange(0, pageCount.length()-1);
-  for(int i=0; i<pageCount.length(); i++){
-    if(i!=0){ PRINTER->newPage(); }
-    //qDebug() << "Printing Page:" << pageCount[i];
+  progress->setRange(0, pageCount.length() - 1);
+  for (int i = 0; i < pageCount.length(); i++) {
+    if (i != 0) {
+      PRINTER->newPage();
+    }
+    // qDebug() << "Printing Page:" << pageCount[i];
     progress->setValue(i);
     QApplication::processEvents();
-    QImage img = BACKEND->imageHash(pageCount[i]).scaled(sz, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    //Now draw the image
-    painter.drawImage(0,0,img);
-    //Also paint the annotations at their locations
-    for(int k = 0; k < BACKEND->annotSize(i); k++) {
+    QImage img = BACKEND->imageHash(pageCount[i])
+                     .scaled(sz, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    // Now draw the image
+    painter.drawImage(0, 0, img);
+    // Also paint the annotations at their locations
+    for (int k = 0; k < BACKEND->annotSize(i); k++) {
       Annotation *annot = BACKEND->annotList(i, k);
-      if(annot->print()) {
-        if(annot->getType() == 14) {
+      if (annot->print()) {
+        if (annot->getType() == 14) {
           painter.setPen(QPen(annot->getColor()));
-          foreach(QVector<QPointF> pointList, annot->getInkList())
+          foreach (QVector<QPointF> pointList, annot->getInkList())
             painter.drawLines(pointList);
-        }else{
+        } else {
           painter.drawImage(annot->getLoc(), annot->renderImage());
         }
       }
@@ -501,23 +638,31 @@ void MainUI::paintToPrinter(QPrinter *PRINTER){
   progAct->setVisible(false);
 }
 
-void MainUI::OpenNewFile(){
-  //Prompt for a file
-  QString path = QFileDialog::getOpenFileName(this, tr("Open PDF"), lastdir, tr("PDF Documents (*.pdf)"));
-  //Now Open it
-  if(!path.isEmpty()){ loadFile(path); }
+void MainUI::OpenNewFile() {
+  // Prompt for a file
+  QString path = QFileDialog::getOpenFileName(this, tr("Open PDF"), lastdir,
+                                              tr("PDF Documents (*.pdf)"));
+  // Now Open it
+  if (!path.isEmpty()) {
+    loadFile(path);
+  }
 }
 
-void MainUI::updateClock(){
-  label_clock->setText( QDateTime::currentDateTime().toString("<b>hh:mm:ss</b>") );
+void MainUI::updateClock() {
+  label_clock->setText(
+      QDateTime::currentDateTime().toString("<b>hh:mm:ss</b>"));
 }
 
-void MainUI::updatePageNumber(){
-  //qDebug() << "UpdatePageNumber";
+void MainUI::updatePageNumber() {
+  // qDebug() << "UpdatePageNumber";
   QString text;
-  if(presentationLabel==0 || !presentationLabel->isVisible()){ text = tr("Page %1 of %2"); }
-  else{ text = "%1/%2"; }
-  label_page->setText( text.arg( QString::number(WIDGET->currentPage()), QString::number(BACKEND->numPages()) ));
+  if (presentationLabel == 0 || !presentationLabel->isVisible()) {
+    text = tr("Page %1 of %2");
+  } else {
+    text = "%1/%2";
+  }
+  label_page->setText(text.arg(QString::number(WIDGET->currentPage()),
+                               QString::number(BACKEND->numPages())));
 }
 
 /*void MainUI::setScroll(bool tog) {
@@ -528,113 +673,133 @@ void MainUI::updatePageNumber(){
   }
 }*/
 
-void MainUI::updateContextMenu(){
+void MainUI::updateContextMenu() {
   contextMenu->clear();
-  contextMenu->addSection( QString(tr("Page %1 of %2")).arg(QString::number(WIDGET->currentPage()),
-    QString::number(BACKEND->numPages()) ) );
+  contextMenu->addSection(QString(tr("Page %1 of %2"))
+                              .arg(QString::number(WIDGET->currentPage()),
+                                   QString::number(BACKEND->numPages())));
   contextMenu->addAction(ui->actionPrevious_Page);
   contextMenu->addAction(ui->actionNext_Page);
   contextMenu->addSeparator();
   contextMenu->addAction(ui->actionFirst_Page);
   contextMenu->addAction(ui->actionLast_Page);
   contextMenu->addSeparator();
-  if(presentationLabel==0 || !presentationLabel->isVisible()){
+  if (presentationLabel == 0 || !presentationLabel->isVisible()) {
     contextMenu->addAction(ui->actionStart_Begin);
     contextMenu->addAction(ui->actionStart_Here);
-  }else{
+  } else {
     contextMenu->addAction(ui->actionStop_Presentation);
   }
 }
 
-void MainUI::keyPressEvent(QKeyEvent *event){
-  //See if this is one of the special hotkeys and act appropriately
-  bool inPresentation = (presentationLabel!=0);
-  if( event->key()==Qt::Key_Escape || event->key()==Qt::Key_Backspace){
-    if(inPresentation){ endPresentation(); }
-  }else if(event->key()==Qt::Key_Right || event->key()==Qt::Key_Space ||
-  event->key()==Qt::Key_PageDown){
+void MainUI::keyPressEvent(QKeyEvent *event) {
+  // See if this is one of the special hotkeys and act appropriately
+  bool inPresentation = (presentationLabel != 0);
+  switch (event->key()) {
+  case Qt::Key_Escape:
+  case Qt::Key_Backspace: {
+    if (inPresentation)
+      endPresentation();
+  } break;
+  case Qt::Key_Right:
+  case Qt::Key_Space:
+  case Qt::Key_PageDown: {
     nextPage();
-  }else if(event->key()==Qt::Key_Left || event->key()==Qt::Key_PageUp){
+  } break;
+  case Qt::Key_Left:
+  case Qt::Key_PageUp: {
     prevPage();
-  }else if(event->key()==Qt::Key_Home){
+  } break;
+  case Qt::Key_Home: {
     firstPage();
-  }else if(event->key()==Qt::Key_End){
+  } break;
+  case Qt::Key_End: {
     lastPage();
-  }else if(event->key()==Qt::Key_F11){
-    if(inPresentation){ endPresentation(); }
-    else{ startPresentationHere(); }
-  }else if(event->key() == Qt::Key_Up) {
-    //Scroll the widget up
-  }else if(event->key() == Qt::Key_Down) {
-    //Scroll the widget down
+  } break;
+  case Qt::Key_F11: {
+    if (inPresentation) {
+      endPresentation();
+    } else {
+      startPresentationHere();
+    }
+  } break;
+  case Qt::Key_Up: {
+    // Scroll the widget up
+  } break;
+  case Qt::Key_Down: {
+    // Scroll the widget down
     /*qDebug() << "Send Wheel Event";
-    QWheelEvent wEvent( WIDGET->mapFromGlobal(QCursor::pos()), QCursor::pos(),QPoint(0,0), QPoint(0,30), 0, Qt::Vertical, Qt::LeftButton, Qt::NoModifier);
-    QApplication::sendEvent(WIDGET, &wEvent);*/
-  }else if(event->key() == Qt::Key_Enter) {
+    QWheelEvent wEvent( WIDGET->mapFromGlobal(QCursor::pos()),
+    QCursor::pos(),QPoint(0,0), QPoint(0,30), 0, Qt::Vertical, Qt::LeftButton,
+    Qt::NoModifier); QApplication::sendEvent(WIDGET, &wEvent);*/
+  } break;
+  case Qt::Key_Enter: {
     /*if(ui->findGroup->hasFocus()) {
       find(ui->textEdit->text(), true);
     }*/
-  }else{
-    QMainWindow::keyPressEvent(event);
+  } break;
+  default: { QMainWindow::keyPressEvent(event); } break;
   }
+
+  return;
 }
 
 void MainUI::wheelEvent(QWheelEvent *event) {
-  //Scroll the window according to the mouse wheel
+  // Scroll the window according to the mouse wheel
   QMainWindow::wheelEvent(event);
 }
 
 void MainUI::find(QString text, bool forward) {
-  if(!text.isEmpty()) {
+  if (!text.isEmpty()) {
     static bool previousMatchCase = matchCase;
-    //qDebug() << "Finding Text";
-    //Detemine if it is the first time searching or a new search string
+    // qDebug() << "Finding Text";
+    // Detemine if it is the first time searching or a new search string
     bool newSearch = results.empty() || !(results[0]->text() == text);
 
-    //Also search again if match case is turned on/off
-    if(previousMatchCase != matchCase) {
+    // Also search again if match case is turned on/off
+    if (previousMatchCase != matchCase) {
       newSearch = true;
       previousMatchCase = matchCase;
     }
 
-    //Clear results and highlights if the user gives a new search string
-    if(newSearch) {
-      //clear out the old results
-      if(!results.empty()) {
-        foreach (TextData* td, results)
+    // Clear results and highlights if the user gives a new search string
+    if (newSearch) {
+      // clear out the old results
+      if (!results.empty()) {
+        foreach (TextData *td, results)
           delete td;
         results.clear();
       }
       WIDGET->updatePreview();
       ui->resultsLabel->setText("");
-      //Get the new search results
+      // Get the new search results
       results = BACKEND->searchDocument(text, matchCase);
-      //qDebug() << "Total Results: " << results.size();
+      // qDebug() << "Total Results: " << results.size();
       currentHighlight = (forward) ? -1 : results.size();
     }
 
-    //qDebug() << "Jumping to next result";
-    if(!results.empty()) {
-      //Jump to the location of the next or previous textbox and highlight
-      if(forward) {
+    // qDebug() << "Jumping to next result";
+    if (!results.empty()) {
+      // Jump to the location of the next or previous textbox and highlight
+      if (forward) {
         currentHighlight++;
-        if(currentHighlight >= results.size())
-        currentHighlight %= results.size();
-      }else{
+        if (currentHighlight >= results.size())
+          currentHighlight %= results.size();
+      } else {
         currentHighlight--;
-        //Ensure currentHighlight will be between 0 and results.size() - 1
-        if(currentHighlight < 0)
+        // Ensure currentHighlight will be between 0 and results.size() - 1
+        if (currentHighlight < 0)
           currentHighlight = results.size() - 1;
       }
 
-
-      ui->resultsLabel->setText(QString::number(currentHighlight+1) + " of " + QString::number(results.size()) + " results");
+      ui->resultsLabel->setText(QString::number(currentHighlight + 1) + " of " +
+                                QString::number(results.size()) + " results");
 
       TextData *currentText = results[currentHighlight];
 
-      if(BACKEND->supportsExtraFeatures()) {
+      if (BACKEND->supportsExtraFeatures()) {
         WIDGET->highlightText(currentText);
-      }else{
+      } else {
         ui->resultsLabel->setText("No results found");
       }
     }

--- a/src-qt5/desktop-utils/lumina-pdf/mainUI.h
+++ b/src-qt5/desktop-utils/lumina-pdf/mainUI.h
@@ -7,31 +7,31 @@
 #ifndef _LUMINA_PDF_VIEWER_MAIN_WINDOW_H
 #define _LUMINA_PDF_VIEWER_MAIN_WINDOW_H
 
-#include <QPrintPreviewWidget>
-#include <QPrintDialog>
-#include <QPrinter>
-#include <QMainWindow>
-#include <QProgressBar>
-#include <QLabel>
-#include <QKeyEvent>
-#include <QDebug>
-#include <QWheelEvent>
 #include <QApplication>
+#include <QDebug>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QMainWindow>
 #include <QMenu>
+#include <QPrintDialog>
+#include <QPrintPreviewWidget>
+#include <QPrinter>
+#include <QProgressBar>
 #include <QTimer>
+#include <QWheelEvent>
 
-#include "Renderer.h"
 #include "BookmarkMenu.h"
 #include "PresentationLabel.h"
-#include "PropDialog.h"
 #include "PrintWidget.h"
+#include "PropDialog.h"
+#include "Renderer.h"
 #include "TextData.h"
 
-namespace Ui{
-  class MainUI;
+namespace Ui {
+class MainUI;
 };
 
-class MainUI : public QMainWindow{
+class MainUI : public QMainWindow {
   Q_OBJECT
 public:
   MainUI();
@@ -48,23 +48,23 @@ private:
   QPrintDialog *PrintDLG;
   QString lastdir;
   bool matchCase;
-  QList<TextData*> results;
+  QList<TextData *> results;
   QList<int> loadingQueue;
   int currentHighlight;
 
-  //Other Interface elements
+  // Other Interface elements
   QProgressBar *progress;
-  QAction *progAct; //action associated with the progressbar
+  QAction *progAct; // action associated with the progressbar
   QTimer *clockTimer;
   QMenu *contextMenu;
-  //QFrame *frame_presenter;
+  // QFrame *frame_presenter;
   QLabel *label_clock, *label_page;
   QAction *clockAct, *pageAct;
 
-  //PDF Page Loading cache variables
+  // PDF Page Loading cache variables
   Renderer *BACKEND;
 
-  //Functions/variables for the presentation mode
+  // Functions/variables for the presentation mode
   PresentationLabel *presentationLabel;
   QScreen *getScreen(bool current, bool &cancelled);
   int CurrentPage;
@@ -74,35 +74,40 @@ private:
 
 private slots:
   void startLoadingPages(int degrees = 0);
-  void slotPageLoaded(int);
+  void slotPageLoaded();
+  void slotSetProgress(int);
 
-  //Simplification routines
-  void nextPage(){ ShowPage( WIDGET->currentPage()+1 ); } //currentPage() starts at 1 rather than 0
-  void prevPage(){ ShowPage( WIDGET->currentPage()-1 ); } //currentPage() starts at 1 rather than 0
-  void firstPage(){ ShowPage(1); }
-  void lastPage(){ ShowPage(BACKEND->numPages()); }
-  void startPresentationHere(){ startPresentation(false); }
-  void startPresentationBeginning(){ startPresentation(true); }
-  void closePresentation(){ endPresentation(); }
+  // Simplification routines
+  void nextPage() {
+    ShowPage(WIDGET->currentPage() + 1);
+  } // currentPage() starts at 1 rather than 0
+  void prevPage() {
+    ShowPage(WIDGET->currentPage() - 1);
+  } // currentPage() starts at 1 rather than 0
+  void firstPage() { ShowPage(1); }
+  void lastPage() { ShowPage(BACKEND->numPages()); }
+  void startPresentationHere() { startPresentation(false); }
+  void startPresentationBeginning() { startPresentation(true); }
+  void closePresentation() { endPresentation(); }
 
   void find(QString text, bool forward);
 
   void paintToPrinter(QPrinter *PRINTER);
 
-  //Button Slots
+  // Button Slots
   void OpenNewFile();
 
-  //Other interface slots
+  // Other interface slots
   void updateClock();
   void updatePageNumber();
-  void showContextMenu(const QPoint&){ contextMenu->popup(QCursor::pos()); }
+  void showContextMenu(const QPoint &) { contextMenu->popup(QCursor::pos()); }
   void updateContextMenu();
-  //void setScroll(bool);
+  // void setScroll(bool);
 
 protected:
-  void keyPressEvent(QKeyEvent*);
-  void wheelEvent(QWheelEvent*);
-  void closeEvent(QCloseEvent *ev){
+  void keyPressEvent(QKeyEvent *);
+  void wheelEvent(QWheelEvent *);
+  void closeEvent(QCloseEvent *ev) {
     endPresentation();
     QMainWindow::closeEvent(ev);
   }


### PR DESCRIPTION
This PR changes the UI so that only one page is displayed on screen at a time. This has significant memory benefits for large PDF files. This also implements a least-recently used image cache of tunable length, which improves responsiveness if you're hopping between two specific pages. I also did some code cleaning, taking classes out of the .cpp files and into their own headers, putting these classes into a project namespace, also formatting the code via clang-format's LLVM style. I also switched some of the containers to standard ones, fixing some race conditions when different threads try to load pages into the shared container.