### PR TITLE
Fix coredump when starting up lumina-fm

### DIFF
--- a/src-qt5/desktop-utils/lumina-fm/Browser.h
+++ b/src-qt5/desktop-utils/lumina-fm/Browser.h
@@ -50,7 +50,7 @@ private:
 private slots:
 	void fileChanged(QString); //tied into the watcher - for file change notifications
 	void dirChanged(QString); // tied into the watcher - for new/removed files in the current dir
-	void futureFinished(QString, QImage);
+	void futureFinished(QString, const QImage* );
 	void updateRequested();
 
 public slots:
@@ -60,13 +60,13 @@ signals:
 	//Main Signals
 	void itemRemoved(QString item); //emitted if a file was removed from the underlying
 	void clearItems(); //emitted when dirs change for example
-	void itemDataAvailable(QIcon, LFileInfo*);
+	void itemDataAvailable(const QIcon*, LFileInfo*);
 
 	//Start/Stop signals for loading of data
 	void itemsLoading(int); //number of items which are getting loaded
 
 	//Internal signal for the alternate threads
-	void threadDone(QString, QImage);
+	void threadDone(QString, const QImage*);
 };
 
 #endif

--- a/src-qt5/desktop-utils/lumina-fm/BrowserWidget.cpp
+++ b/src-qt5/desktop-utils/lumina-fm/BrowserWidget.cpp
@@ -28,7 +28,7 @@ BrowserWidget::BrowserWidget(QString objID, QWidget *parent) : QWidget(parent){
   bThread->start();
   connect(BROWSER, SIGNAL(clearItems()), this, SLOT(clearItems()) );
   connect(BROWSER, SIGNAL(itemRemoved(QString)), this, SLOT(itemRemoved(QString)) );
-  connect(BROWSER, SIGNAL(itemDataAvailable(QIcon, LFileInfo*)), this, SLOT(itemDataAvailable(QIcon, LFileInfo*)) );
+  connect(BROWSER, SIGNAL(itemDataAvailable(const QIcon *, LFileInfo*)), this, SLOT(itemDataAvailable(const QIcon *, LFileInfo*)) );
   connect(BROWSER, SIGNAL(itemsLoading(int)), this, SLOT(itemsLoading(int)) );
   connect(this, SIGNAL(dirChange(QString, bool)), BROWSER, SLOT(loadDirectory(QString, bool)) );
   listWidget = 0;
@@ -99,7 +99,7 @@ void BrowserWidget::showDetails(bool show){
     connect(treeWidget, SIGNAL(DataDropped(QString, QStringList)), this, SIGNAL(DataDropped(QString, QStringList)) );
     connect(treeWidget, SIGNAL(GotFocus()), this, SLOT(selectionChanged()) );
     connect(treeWidget, SIGNAL(sortColumnChanged(int)), this, SIGNAL(treeWidgetSortColumn(int)) );
-    connect(treeWidget, SIGNAL(sortColumnChanged(int)), this, SIGNAL(setTreeWidgetSortColumn(int)) );
+    connect(treeWidget, SIGNAL(sortColumnChanged(int)), this, SIGNAL(setTreeWidgetSortColumn(int, bool)) );
     retranslate();
     treeWidget->sortItems(treeSortColumn, Qt::AscendingOrder);
     treeWidget->setColumnWidth(0, treeWidget->fontMetrics().width("W")*20);
@@ -320,7 +320,7 @@ void BrowserWidget::itemRemoved(QString item){
   }
 }
 
-void BrowserWidget::itemDataAvailable(QIcon ico, LFileInfo *info){
+void BrowserWidget::itemDataAvailable(const QIcon* ico, LFileInfo *info){
   if(info==0){ return; }
   if(listWidget!=0){ listWidget->setWhatsThis( BROWSER->currentDirectory() ); }
   if(treeWidget!=0){ treeWidget->setWhatsThis(BROWSER->currentDirectory() ); }
@@ -347,7 +347,7 @@ void BrowserWidget::itemDataAvailable(QIcon ico, LFileInfo *info){
     }
     //No existing item - make a new one
     if(it==0){
-      it = new CQListWidgetItem(ico, info->fileName(), listWidget);
+      it = new CQListWidgetItem(*ico, info->fileName(), listWidget);
           it->setWhatsThis(info->absoluteFilePath());
           it->setData(Qt::UserRole, (info->isDir() ? "dir" : "file")); //used for sorting
         listWidget->addItem(it);
@@ -356,9 +356,9 @@ void BrowserWidget::itemDataAvailable(QIcon ico, LFileInfo *info){
     //Now update the information for the item
     if(info->isDesktopFile() && info->XDG()->isValid()){
       it->setText(info->XDG()->name);
-      it->setIcon(ico);
+      it->setIcon(*ico);
     }else{
-      it->setIcon(ico);
+      it->setIcon(*ico);
       it->setText(info->fileName());
     }
 
@@ -397,7 +397,7 @@ void BrowserWidget::itemDataAvailable(QIcon ico, LFileInfo *info){
       }
     }
     //Now set/update all the data
-    if(!info->isVideo() || !hasThumbnails() || !USE_VIDEO_LABEL){ it->setIcon(0, ico); }
+    if(!info->isVideo() || !hasThumbnails() || !USE_VIDEO_LABEL){ it->setIcon(0, *ico); }
     it->setText(1, info->isDir() ? "" : LUtils::BytesToDisplaySize(info->size()) ); //size (1)
     it->setText(2, info->mimetype() ); //type (2)
     it->setText(3, DTtoString(info->lastModified() )); //modification date (3)

--- a/src-qt5/desktop-utils/lumina-fm/BrowserWidget.h
+++ b/src-qt5/desktop-utils/lumina-fm/BrowserWidget.h
@@ -61,7 +61,7 @@ public:
 	QStringList history();
 
 	void setShowActive(bool show); //used for accenting if the widget is "active"
-
+	
 	void setTreeWidgetSortColumn(int col, bool now = false);
 
 	QString status(){ return statustip; }
@@ -80,7 +80,7 @@ private slots:
 	//Browser connections
 	void clearItems();
 	void itemRemoved(QString);
-	void itemDataAvailable(QIcon, LFileInfo*);
+	void itemDataAvailable(const QIcon*, LFileInfo*);
 	void itemsLoading(int total);
 	void selectionChanged();
 	void loadStatistics(BrowserWidget *bw); //designed to be run in a background thread


### PR DESCRIPTION
It seems the issue was caused by some corrupted QImage pointer  during its dereferencing in order to pass to futureFinished() slot

Changing slot signature from call-by-value to call-by-reference / pointer and adding explicit check for std::nullptr fixed the crash problem. The lumina-fm started up successfully.


Here is one GDB backtrace
> Core was generated by `lumina-fm'.
> Program terminated with signal SIGSEGV, Segmentation fault.
> #0  0x0000000800d18006 in QImage::QImage(QImage const&) () from /usr/local/lib/qt5/libQt5Gui.so.5
> [Current thread is 1 (LWP 102634)]
> (gdb) bt
> #0  0x0000000800d18006 in QImage::QImage(QImage const&) () at /usr/local/lib/qt5/libQt5Gui.so.5
> #1  0x00000000003266f7 in  ()
> #2  0x0000000801651641 in QObject::event(QEvent*) () at /usr/local/lib/qt5/libQt5Core.so.5
> #3  0x000000080067af61 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /usr/local/lib/qt5/libQt5Widgets.so.5
> #4  0x000000080067c359 in QApplication::notify(QObject*, QEvent*) () at /usr/local/lib/qt5/libQt5Widgets.so.5
> #5  0x0000000801626ee1 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /usr/local/lib/qt5/libQt5Core.so.5
> #6  0x0000000801627da9 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) () at /usr/local/lib/qt5/libQt5Core.so.5
> #7  0x0000000801678fd8 in QEventDispatcherUNIX::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/local/lib/qt5/libQt5Core.so.5
> #8  0x0000000801622a2e in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/local/lib/qt5/libQt5Core.so.5
> #9  0x000000080145fdec in QThread::exec() () at /usr/local/lib/qt5/libQt5Core.so.5
> #10 0x0000000801460c83 in  () at /usr/local/lib/qt5/libQt5Core.so.5
> #11 0x00000008018d5756 in thread_start (curthread=0x8061a5100) at /usr/src_tmp/lib/libthr/thread/thr_create.c:291
> #12 0x0000000000000000 in  ()
> 