### PR TITLE
Missing LuminaPDF::LRUCache::contains() method causing compilation error

### DIFF
--- a/src-qt5/desktop-utils/lumina-pdf/lrucache.h
+++ b/src-qt5/desktop-utils/lumina-pdf/lrucache.h
@@ -44,6 +44,10 @@ public:
     hashmap[k] = values.begin();
   }
 
+  bool contains(const Key k) {
+     return get(k).has_value();
+  }
+
 private:
   size_t max;
   std::list<std::tuple<Key, Value>> values;


### PR DESCRIPTION
Fix for https://github.com/lumina-desktop/lumina/issues/662