### PR TITLE
[lumina-photo] Fix fit picture from CLI

### DIFF
--- a/src-qt5/desktop-utils/lumina-photo/PhotoView.h
+++ b/src-qt5/desktop-utils/lumina-photo/PhotoView.h
@@ -18,7 +18,7 @@ class PhotoView : public QGraphicsView
         const double invScaleFactor = 1 / 1.25;
         bool eventFilter(QObject *, QEvent *event);
         void mouseDoubleClickEvent(QMouseEvent *event);
-        bool isFit = true;
+        bool isFit = false;
 
     signals:
         void nextImage();

--- a/src-qt5/desktop-utils/lumina-photo/main.cpp
+++ b/src-qt5/desktop-utils/lumina-photo/main.cpp
@@ -36,7 +36,7 @@ int main (int argc, char *argv[])
     }
     // Now start the window
     MainUI W;
-    W.loadArguments (args);
     W.show ();
+    W.loadArguments (args);
     return a.exec ();
 }


### PR DESCRIPTION
loadArguments method was called before the window was created so the sceneRect() was wrong.

Before

``` % lumina-photo myPicture.png ```
![image](https://user-images.githubusercontent.com/7521540/67334856-2088af80-f523-11e9-93c0-8906728f5236.png)

After

``` % lumina-photo myPicture.png ```
![image](https://user-images.githubusercontent.com/7521540/67334960-457d2280-f523-11e9-8f15-eaedd1778480.png)
