### PR TITLE
Draft: CMake-ify the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ src-qt5/desktop-utils/lumina-archiver/lumina-archiver
 src-qt5/desktop-utils/lumina-calculator/lumina-calculator
 src-qt5/desktop-utils/lumina-pdf/lumina-pdf
 src-qt5/desktop-utils/lumina-notify/lumina-notify
-src-qt5/core/lumina-theme-engine/src/lthemeengine-qtplugin/
 src-qt5/core/lumina-theme-engine/src/lthemeengine-qtplugin/Makefile
 src-qt5/core/lumina-theme-engine/src/lthemeengine-qtplugin/liblthemeengine.so
 src-qt5/core/lumina-theme-engine/src/lthemeengine-sstest/Makefile
@@ -58,3 +57,6 @@ icon-theme/*/Makefile
 ./Makefile
 src-qt5/src-qml/test/*
 src-qt5/desktop-utils/lumina-pdf/fontconfig/*
+
+# CMake-build parts
+src-qt5/core/build/

--- a/icon-theme/CMakeLists.txt
+++ b/icon-theme/CMakeLists.txt
@@ -4,9 +4,16 @@
 # SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
 
 include(CMakeParseArguments)
+
+# Installs files for a theme. The theme must have a NAME.
+# Files are globbed from SUBDIRS, which are assumed to contain
+# only SVGs. Those files are installed to corresponding TARGET_SUBDIR/SUBDIRS
+# in the destination. TARGET_SUBDIR is optional (some themes are scalable/,
+# some aren't). Files listed explicitly in TOPLEVEL are installed at the
+# top-level of the theme.
 function(install_theme)
     set(options "") # None
-    set(oneValueArgs NAME)
+    set(oneValueArgs NAME TARGET_SUBDIR)
     set(multiValueArgs TOPLEVEL SUBDIRS)
 
     cmake_parse_arguments(
@@ -26,10 +33,13 @@ function(install_theme)
     install(FILES ${THEME_TOPLEVEL} DESTINATION ${target_directory})
     foreach(d ${THEME_SUBDIRS})
         file(GLOB_RECURSE files "${d}/*.svg")
-        install(FILES ${files} DESTINATION ${target_directory}/${d})
+        install(
+            FILES ${files}
+            DESTINATION ${target_directory}/${THEME_TARGET_SUBDIR}/${d}
+        )
     endforeach()
 endfunction()
 
 add_subdirectory(lumina-icons)
-# add_subdirectory(material-design-light)
-# add_subdirectory(material-design-dark)
+add_subdirectory(material-design-light)
+add_subdirectory(material-design-dark)

--- a/icon-theme/CMakeLists.txt
+++ b/icon-theme/CMakeLists.txt
@@ -1,0 +1,35 @@
+# lumina-core/icon-themes build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+include(CMakeParseArguments)
+function(install_theme)
+    set(options "") # None
+    set(oneValueArgs NAME)
+    set(multiValueArgs TOPLEVEL SUBDIRS)
+
+    cmake_parse_arguments(
+        THEME
+        "${options}"
+        "${oneValueArgs}"
+        "${multiValueArgs}"
+        ${ARGN}
+    )
+
+    if(NOT THEME_NAME)
+        message(FATAL_ERROR "Missing theme name")
+    endif()
+
+    set(target_directory "${CMAKE_INSTALL_DATADIR}/icons/${THEME_NAME}")
+
+    install(FILES ${THEME_TOPLEVEL} DESTINATION ${target_directory})
+    foreach(d ${THEME_SUBDIRS})
+        file(GLOB_RECURSE files "${d}/*.svg")
+        install(FILES ${files} DESTINATION ${target_directory}/${d})
+    endforeach()
+endfunction()
+
+add_subdirectory(lumina-icons)
+# add_subdirectory(material-design-light)
+# add_subdirectory(material-design-dark)

--- a/icon-theme/lumina-icons/CMakeLists.txt
+++ b/icon-theme/lumina-icons/CMakeLists.txt
@@ -1,0 +1,16 @@
+# lumina-icons installation, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+# This is assumed to be used from inside the icon-theme/CMakeLists,
+# which in turn is part of the lumina-core build -- even though
+# the source-repository layout doesn't suggest that is the case.
+
+install_theme(
+    NAME "lumina-icons"
+    TOPLEVEL 
+        "index.theme"
+    SUBDIRS
+        "actions/symbolic"
+)

--- a/icon-theme/material-design-dark/CMakeLists.txt
+++ b/icon-theme/material-design-dark/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Theme installation, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+# This is assumed to be used from inside the icon-theme/CMakeLists,
+# which in turn is part of the lumina-core build -- even though
+# the source-repository layout doesn't suggest that is the case.
+
+install_theme(
+    NAME "material-design-light"
+    TARGET_SUBDIR "scalable"
+    TOPLEVEL 
+        "index.theme"
+        "LICENSE"
+    SUBDIRS
+        actions
+        applications
+        categories
+        devices
+        emblems
+        emotes
+        international
+        mimetypes
+        places
+        status
+)

--- a/icon-theme/material-design-light/CMakeLists.txt
+++ b/icon-theme/material-design-light/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Theme installation, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+# This is assumed to be used from inside the icon-theme/CMakeLists,
+# which in turn is part of the lumina-core build -- even though
+# the source-repository layout doesn't suggest that is the case.
+
+install_theme(
+    NAME "material-design-dark"
+    TARGET_SUBDIR "scalable"
+    TOPLEVEL 
+        "index.theme"
+        "LICENSE"
+    SUBDIRS
+        actions
+        applications
+        categories
+        devices
+        emblems
+        emotes
+        international
+        mimetypes
+        places
+        status
+)

--- a/src-qt5/core/CMakeLists.txt
+++ b/src-qt5/core/CMakeLists.txt
@@ -8,6 +8,7 @@ project(lumina-core VERSION 1.6.2 LANGUAGES C CXX) # TODO: inherit this from top
 # CMake Settings (policies to do AUTOMOC as much as possible)
 cmake_policy(SET CMP0057 NEW)
 cmake_policy(SET CMP0071 NEW)
+include(GNUInstallDirs)
 
 # C++ Settings (pretend everything is modern)
 set(CMAKE_CXX_STANDARD 17)

--- a/src-qt5/core/CMakeLists.txt
+++ b/src-qt5/core/CMakeLists.txt
@@ -53,7 +53,19 @@ find_package(X11)
 find_package(
     XCB
     MODULE
-    COMPONENTS XCB KEYSYMS XKB XFIXES DAMAGE DPMS EWMH ICCCM IMAGE
+    COMPONENTS
+        XCB
+        KEYSYMS
+        XKB
+        XFIXES
+        AUX
+        COMPOSITE
+        DAMAGE
+        DPMS
+        EWMH
+        ICCCM
+        IMAGE
+        SCREENSAVER
     OPTIONAL_COMPONENTS XTEST
 )
 if(NOT X11_FOUND OR NOT XCB_XCB_FOUND)

--- a/src-qt5/core/CMakeLists.txt
+++ b/src-qt5/core/CMakeLists.txt
@@ -1,0 +1,77 @@
+# lumina-core build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+project(lumina-core VERSION 1.6.2 LANGUAGES C CXX) # TODO: inherit this from top-level
+
+# CMake Settings (policies to do AUTOMOC as much as possible)
+cmake_policy(SET CMP0057 NEW)
+cmake_policy(SET CMP0071 NEW)
+
+# C++ Settings (pretend everything is modern)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ECM setup
+include(FeatureSummary)
+find_package(ECM 5.88.0 NO_MODULE)
+set_package_properties(
+    ECM
+    PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "Extra CMake Modules."
+    URL "https://commits.kde.org/extra-cmake-modules"
+)
+feature_summary(
+    WHAT REQUIRED_PACKAGES_NOT_FOUND
+    FATAL_ON_MISSING_REQUIRED_PACKAGES
+)
+
+set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
+
+# Dependencies
+set(QT_VERSION 5.15.0)
+find_package(
+    Qt5
+    ${QT_VERSION}
+    CONFIG
+    REQUIRED
+        Concurrent
+        Core
+        Gui
+        Multimedia
+        MultimediaWidgets
+        Network
+        Quick
+        Qml
+        Svg
+        Widgets
+        X11Extras
+)
+find_package(X11)
+find_package(
+    XCB
+    MODULE
+    COMPONENTS XCB KEYSYMS XKB XFIXES DAMAGE DPMS EWMH ICCCM IMAGE
+    OPTIONAL_COMPONENTS XTEST
+)
+if(NOT X11_FOUND OR NOT XCB_XCB_FOUND)
+    message(FATAL_ERROR "Required XCB component for X11 not found.")
+endif()
+
+# OS-detection
+#
+# This ignores the actual OS and just sets FreeBSD-useful values
+add_definitions(
+    -DL_ETCDIR=QStringLiteral\("${CMAKE_INSTALL_PREFIX}/etc"\)
+    -DL_SHAREDIR=QStringLiteral\("${CMAKE_INSTALL_PREFIX}/share"\)
+)
+
+# Build options
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+
+# Lumina Components
+add_subdirectory(libLumina)
+add_subdirectory(lumina-desktop)

--- a/src-qt5/core/CMakeLists.txt
+++ b/src-qt5/core/CMakeLists.txt
@@ -88,6 +88,11 @@ set(CMAKE_AUTOUIC ON)
 # Lumina Components
 add_subdirectory(libLumina)
 add_subdirectory(lumina-desktop)
+add_subdirectory(lumina-session)
+add_subdirectory(lumina-open)
+add_subdirectory(lumina-info)
+add_subdirectory(lumina-pingcursor)
+add_subdirectory(lumina-theme-engine)
 
 # Additional files
 

--- a/src-qt5/core/CMakeLists.txt
+++ b/src-qt5/core/CMakeLists.txt
@@ -88,3 +88,29 @@ set(CMAKE_AUTOUIC ON)
 # Lumina Components
 add_subdirectory(libLumina)
 add_subdirectory(lumina-desktop)
+
+# Additional files
+
+install(
+    FILES menu-scripts/README.md menu-scripts/ls.json.sh
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/lumina-desktop/menu-scripts
+)
+install(
+    FILES
+        themes/DarkGlass.qss.template
+        themes/Glass.qss.template
+        themes/Lumina-default.qss.template
+        themes/None.qss.template
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/lumina-desktop/themes
+)
+
+# This is a typo, also in the original core.pro, should be xtrafiles/theme.cfg
+#
+#install(
+#    FILES extrafiles/theme.cfg
+#    DESTINATION ${CMAKE_INSTALL_DATADIR}/fluxbox/style/lumina-dark/theme.cfg
+#)
+install(
+    FILES xtrafiles/globs2
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/lumina-desktop
+)

--- a/src-qt5/core/CMakeLists.txt
+++ b/src-qt5/core/CMakeLists.txt
@@ -114,3 +114,10 @@ install(
     FILES xtrafiles/globs2
     DESTINATION ${CMAKE_INSTALL_DATADIR}/lumina-desktop
 )
+
+# The icon theme lives outside of core, but should be
+# installed along with it. The icon-themes here is the
+# binary-directory to use during the build; there isn't
+# much to do there except write Makefiles, since the
+# icon themes do nothing but copy files out of the source-tree.
+add_subdirectory(../../icon-theme icon-themes)

--- a/src-qt5/core/libLumina/CMakeLists.txt
+++ b/src-qt5/core/libLumina/CMakeLists.txt
@@ -1,0 +1,39 @@
+# lumina-core/libLumina build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+add_library(
+    libLumina
+    STATIC
+    DesktopSettings.cpp
+    LDesktopUtils.cpp
+    LFileInfo.cpp
+    LIconCache.cpp
+    LInputDevice.cpp
+    LUtils.cpp
+    LVideoLabel.cpp
+    LVideoSurface.cpp
+    LVideoWidget.cpp
+    LuminaRandR-X11.cpp
+    LuminaSingleApplication.cpp
+    LuminaThemes.cpp
+    LuminaX11.cpp
+    LuminaXDG.cpp
+    ResizeMenu.cpp
+    XDGMime.cpp
+)
+if(CMAKE_SYSTEM MATCHES "FreeBSD")
+    target_sources(libLumina PUBLIC LuminaOS-FreeBSD.cpp)
+endif()
+
+target_include_directories(libLumina PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+    libLumina
+    PUBLIC
+        Qt5::Concurrent
+        Qt5::Core
+        Qt5::MultimediaWidgets
+        Qt5::Svg
+        Qt5::Widgets
+        Qt5::X11Extras
+)

--- a/src-qt5/core/libLumina/CMakeLists.txt
+++ b/src-qt5/core/libLumina/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(
     LuminaXDG.cpp
     ResizeMenu.cpp
     XDGMime.cpp
+    # Header-only classes
+    ExternalProcess.h
 )
 if(CMAKE_SYSTEM MATCHES "FreeBSD")
     target_sources(libLumina PUBLIC LuminaOS-FreeBSD.cpp)

--- a/src-qt5/core/libLumina/CMakeLists.txt
+++ b/src-qt5/core/libLumina/CMakeLists.txt
@@ -36,4 +36,9 @@ target_link_libraries(
         Qt5::Svg
         Qt5::Widgets
         Qt5::X11Extras
+        XCB::XCB
+        XCB::AUX
+        XCB::DAMAGE
+        XCB::SCREENSAVER
+        X11::Xdamage
 )

--- a/src-qt5/core/lumina-desktop/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/CMakeLists.txt
@@ -78,6 +78,7 @@ install(
         audiofiles/Login.ogg
         audiofiles/Logout.ogg
         audiofiles/low-battery.ogg
+        extrafiles/Lumina-DE.png
         fluxboxconf/fluxbox-init-rc
         fluxboxconf/fluxbox-keys
         fluxboxconf/theme.cfg

--- a/src-qt5/core/lumina-desktop/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(
     src-screensaver
 )
 
+add_subdirectory(desktop-plugins)
 add_subdirectory(panel-plugins)
 add_subdirectory(src-screensaver)
 
@@ -33,7 +34,6 @@ add_executable(
     SettingsMenu.cpp
     SystemWindow.cpp
     BootSplash.cpp
-    desktop-plugins/LDPlugin.cpp
     # Header-only classes
     JsonMenu.h
 )
@@ -68,5 +68,5 @@ target_link_libraries(
 # The panel-plugins have their own static library
 target_link_libraries(
     lumina-desktop
-    PRIVATE integrated-panel integrated-screensaver
+    PRIVATE integrated-desktop integrated-panel integrated-screensaver
 )

--- a/src-qt5/core/lumina-desktop/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/CMakeLists.txt
@@ -6,10 +6,11 @@
 # The plugins, as well as sources in this directory, expect to
 # include from this directory, from src-screensaver/, but **also* from
 # the top-level (outside of lumina-core entirely!) src-cpp.
+set(TOPLEVEL_SRC_CPP ${CMAKE_SOURCE_DIR}/../src-cpp/)
 include_directories(
     lumina-desktop
     PRIVATE
-    ${CMAKE_SOURCE_DIR}/../src-cpp/
+    ${TOPLEVEL_SRC_CPP}
     ${CMAKE_CURRENT_LIST_DIR}
     src-screensaver
 )
@@ -33,7 +34,20 @@ add_executable(
     SystemWindow.cpp
     BootSplash.cpp
     desktop-plugins/LDPlugin.cpp
+    # Header-only classes
+    JsonMenu.h
 )
+# FIXME: because we're CMake-ifying only core,
+# the src-cpp bits lie "outside" the regular source tree.
+# Make that a library at some point.
+target_sources(
+    lumina-desktop
+    PUBLIC
+        ${TOPLEVEL_SRC_CPP}/plugins-base.cpp
+        ${TOPLEVEL_SRC_CPP}/plugins-desktop.cpp
+        ${TOPLEVEL_SRC_CPP}/plugins-screensaver.cpp
+)
+
 # Picks up many Qt libraries from libLumina's PUBLIC settings
 target_link_libraries(
     lumina-desktop

--- a/src-qt5/core/lumina-desktop/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/CMakeLists.txt
@@ -1,0 +1,57 @@
+# lumina-core/lumina-desktop build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+# The plugins, as well as sources in this directory, expect to
+# include from this directory, from src-screensaver/, but **also* from
+# the top-level (outside of lumina-core entirely!) src-cpp.
+include_directories(
+    lumina-desktop
+    PRIVATE
+    ${CMAKE_SOURCE_DIR}/../src-cpp/
+    ${CMAKE_CURRENT_LIST_DIR}
+    src-screensaver
+)
+
+add_subdirectory(panel-plugins)
+add_subdirectory(src-screensaver)
+
+add_executable(
+    lumina-desktop
+    main.cpp
+    WMProcess.cpp
+    LXcbEventFilter.cpp
+    LSession.cpp
+    LDesktop.cpp
+    LDesktopBackground.cpp
+    LDesktopPluginSpace.cpp
+    LPanel.cpp
+    LWinInfo.cpp
+    AppMenu.cpp
+    SettingsMenu.cpp
+    SystemWindow.cpp
+    BootSplash.cpp
+    desktop-plugins/LDPlugin.cpp
+)
+# Picks up many Qt libraries from libLumina's PUBLIC settings
+target_link_libraries(
+    lumina-desktop
+    PRIVATE
+        libLumina
+        Qt5::Gui
+        Qt5::Network
+        Qt5::Quick
+        Qt5::Qml
+        XCB::XCB
+        XCB::DAMAGE
+        XCB::DPMS
+        XCB::EWMH
+        XCB::ICCCM
+        XCB::IMAGE
+)
+# The panel-plugins have their own static library
+target_link_libraries(
+    lumina-desktop
+    PRIVATE integrated-panel integrated-screensaver
+)

--- a/src-qt5/core/lumina-desktop/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/CMakeLists.txt
@@ -70,3 +70,9 @@ target_link_libraries(
     lumina-desktop
     PRIVATE integrated-desktop integrated-panel integrated-screensaver
 )
+
+install(TARGETS lumina-desktop)
+install(
+    FILES audiofiles/Login.ogg audiofiles/Logout.ogg audiofiles/low-battery.ogg
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/lumina-desktop/
+)

--- a/src-qt5/core/lumina-desktop/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(
         Qt5::Quick
         Qt5::Qml
         XCB::XCB
+        XCB::COMPOSITE
         XCB::DAMAGE
         XCB::DPMS
         XCB::EWMH

--- a/src-qt5/core/lumina-desktop/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/CMakeLists.txt
@@ -70,9 +70,21 @@ target_link_libraries(
     lumina-desktop
     PRIVATE integrated-desktop integrated-panel integrated-screensaver
 )
-
 install(TARGETS lumina-desktop)
+
+# Additional files
 install(
-    FILES audiofiles/Login.ogg audiofiles/Logout.ogg audiofiles/low-battery.ogg
+    FILES
+        audiofiles/Login.ogg
+        audiofiles/Logout.ogg
+        audiofiles/low-battery.ogg
+        fluxboxconf/fluxbox-init-rc
+        fluxboxconf/fluxbox-keys
+        fluxboxconf/theme.cfg
     DESTINATION ${CMAKE_INSTALL_DATADIR}/lumina-desktop/
+)
+install(FILES Lumina-DE.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/xsessions/)
+install(
+    FILES Lumina-DE.svg
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps/
 )

--- a/src-qt5/core/lumina-desktop/SystemWindow.h
+++ b/src-qt5/core/lumina-desktop/SystemWindow.h
@@ -3,8 +3,6 @@
 
 #include <QDialog>
 
-#include "ui_SystemWindow.h"
-
 namespace Ui{
 	class SystemWindow;
 };

--- a/src-qt5/core/lumina-desktop/desktop-plugins/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/desktop-plugins/CMakeLists.txt
@@ -1,0 +1,20 @@
+# lumina-core/lumina-desktop/desktop-plugins build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+add_library(
+    integrated-desktop
+    STATIC
+    LDPlugin.cpp
+    applauncher/AppLauncherPlugin.cpp
+    applauncher/OutlineToolButton.h
+    audioplayer/PlayerWidget.cpp
+    desktopview/DesktopViewPlugin.cpp
+    notepad/NotepadPlugin.cpp
+    rssreader/RSSFeedPlugin.cpp
+    rssreader/RSSObjects.cpp
+    systemmonitor/MonitorWidget.cpp
+    # Header-only plugins
+    calendar/CalendarPlugin.h
+)
+target_link_libraries(integrated-desktop PRIVATE libLumina Qt5::Quick)

--- a/src-qt5/core/lumina-desktop/panel-plugins/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/panel-plugins/CMakeLists.txt
@@ -1,0 +1,30 @@
+# lumina-core/lumina-desktop/panel-plugins build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+add_library(
+    integrated-panel
+    STATIC
+    applauncher/AppLaunchButton.cpp
+    appmenu/LAppMenuPlugin.cpp
+    audioplayer/LPAudioPlayer.cpp
+    audioplayer/PPlayerWidget.cpp
+    battery/LBattery.cpp
+    clock/LClock.cpp
+    desktopbar/LDeskBar.cpp
+    desktopswitcher/LDesktopSwitcher.cpp
+    showdesktop/LHomeButton.cpp
+    systemdashboard/LSysDashboard.cpp
+    systemdashboard/SysMenuQuick.cpp
+    systemtray/LSysTray.cpp
+    systemtray/TrayIcon.cpp
+    taskmanager/LTaskManagerPlugin.cpp
+    taskmanager/LTaskButton.cpp
+    userbutton/UserWidget.cpp
+    userbutton/UserItemWidget.cpp
+    systemstart/LStartButton.cpp
+    systemstart/StartMenu.cpp
+    systemstart/ItemWidget.cpp
+    jsonmenu/PPJsonMenu.cpp
+)
+target_link_libraries(integrated-panel PRIVATE libLumina Qt5::Quick)

--- a/src-qt5/core/lumina-desktop/panel-plugins/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/panel-plugins/CMakeLists.txt
@@ -20,11 +20,17 @@ add_library(
     systemtray/TrayIcon.cpp
     taskmanager/LTaskManagerPlugin.cpp
     taskmanager/LTaskButton.cpp
+    userbutton/LUserButton.cpp
     userbutton/UserWidget.cpp
     userbutton/UserItemWidget.cpp
     systemstart/LStartButton.cpp
     systemstart/StartMenu.cpp
     systemstart/ItemWidget.cpp
     jsonmenu/PPJsonMenu.cpp
+    # Header-only classes
+    LPPlugin.h
+    LTBWidget.h
+    line/LLine.h
+    spacer/LSpacer.h
 )
 target_link_libraries(integrated-panel PRIVATE libLumina Qt5::Quick)

--- a/src-qt5/core/lumina-desktop/src-screensaver/CMakeLists.txt
+++ b/src-qt5/core/lumina-desktop/src-screensaver/CMakeLists.txt
@@ -1,0 +1,13 @@
+# lumina-core/lumina-desktop/src-screensaver build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+add_library(
+    integrated-screensaver
+    STATIC
+    LLockScreen.cpp
+    LScreenSaver.cpp
+    SSBaseWidget.cpp
+    animations/BaseAnimGroup.cpp
+)
+target_link_libraries(integrated-screensaver PRIVATE libLumina Qt5::Quick)

--- a/src-qt5/core/lumina-info/CMakeLists.txt
+++ b/src-qt5/core/lumina-info/CMakeLists.txt
@@ -1,0 +1,13 @@
+# lumina-core/lumina-open build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+add_executable(lumina-info main.cpp MainUI.cpp)
+target_link_libraries(
+    lumina-info
+    PRIVATE libLumina Qt5::Core Qt5::Gui Qt5::Widgets Qt5::X11Extras
+)
+install(TARGETS lumina-info)
+
+# TODO: qrc, translations, manpage

--- a/src-qt5/core/lumina-open/CMakeLists.txt
+++ b/src-qt5/core/lumina-open/CMakeLists.txt
@@ -1,0 +1,13 @@
+# lumina-core/lumina-open build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+add_executable(lumina-open main.cpp LFileDialog.cpp)
+target_link_libraries(
+    lumina-open
+    PRIVATE libLumina Qt5::Core Qt5::Gui Qt5::Widgets Qt5::X11Extras
+)
+install(TARGETS lumina-open)
+
+# TODO: qrc, translations, manpage

--- a/src-qt5/core/lumina-pingcursor/CMakeLists.txt
+++ b/src-qt5/core/lumina-pingcursor/CMakeLists.txt
@@ -1,0 +1,8 @@
+# lumina-core/lumina-pingcursor build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+add_executable(lumina-pingcursor main.cpp)
+target_link_libraries(lumina-pingcursor PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets)
+install(TARGETS lumina-pingcursor)

--- a/src-qt5/core/lumina-session/CMakeLists.txt
+++ b/src-qt5/core/lumina-session/CMakeLists.txt
@@ -1,0 +1,11 @@
+# lumina-core/lumina-session build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+add_executable(start-lumina-desktop main.cpp session.cpp)
+target_link_libraries(
+    start-lumina-desktop
+    PRIVATE libLumina Qt5::Core Qt5::Widgets Qt5::X11Extras
+)
+install(TARGETS start-lumina-desktop)

--- a/src-qt5/core/lumina-theme-engine/CMakeLists.txt
+++ b/src-qt5/core/lumina-theme-engine/CMakeLists.txt
@@ -4,6 +4,9 @@
 # SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
 
 add_subdirectory(src/lthemeengine)
+add_subdirectory(src/lthemeengine-qtplugin)
+add_subdirectory(src/lthemeengine-sstest)
+add_subdirectory(src/lthemeengine-style)
 
 install(
     DIRECTORY colors

--- a/src-qt5/core/lumina-theme-engine/CMakeLists.txt
+++ b/src-qt5/core/lumina-theme-engine/CMakeLists.txt
@@ -1,0 +1,25 @@
+# lumina-core/lumina-theme-engine build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+add_subdirectory(src/lthemeengine)
+
+install(
+    DIRECTORY colors
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/lthemeengine/colors
+    FILES_MATCHING
+    PATTERN *.conf
+)
+install(
+    DIRECTORY qss
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/lthemeengine/qss
+    FILES_MATCHING
+    PATTERN *.qss
+)
+install(
+    DIRECTORY desktop_qss
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/lthemeengine/desktop_qss
+    FILES_MATCHING
+    PATTERN *.qss
+)

--- a/src-qt5/core/lumina-theme-engine/src/lthemeengine-qtplugin/CMakeLists.txt
+++ b/src-qt5/core/lumina-theme-engine/src/lthemeengine-qtplugin/CMakeLists.txt
@@ -1,0 +1,6 @@
+# lumina-core/lumina-theme-engine/lthemeengine-qtplugin build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+# TODO: figure out how to do Qt plugins from CMake

--- a/src-qt5/core/lumina-theme-engine/src/lthemeengine-sstest/CMakeLists.txt
+++ b/src-qt5/core/lumina-theme-engine/src/lthemeengine-sstest/CMakeLists.txt
@@ -1,0 +1,8 @@
+# lumina-core/lumina-theme-engine/lthemeengine-sstest build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+add_executable(lthemeengine-sstest main.cpp)
+target_link_libraries(lthemeengine-sstest PRIVATE libLumina Qt5::Widgets)
+install(TARGETS lthemeengine-sstest)

--- a/src-qt5/core/lumina-theme-engine/src/lthemeengine-style/CMakeLists.txt
+++ b/src-qt5/core/lumina-theme-engine/src/lthemeengine-style/CMakeLists.txt
@@ -1,0 +1,6 @@
+# lumina-core/lumina-theme-engine/lthemeengine-style build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+# TODO: figure out how to build a style plugin from CMake

--- a/src-qt5/core/lumina-theme-engine/src/lthemeengine/CMakeLists.txt
+++ b/src-qt5/core/lumina-theme-engine/src/lthemeengine/CMakeLists.txt
@@ -1,0 +1,26 @@
+# lumina-core/lumina-theme-engine/lthemeengine build, CMake edition. EXPERIMENTAL.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: Copyright 2022 Adriaan de Groot <adridg@FreeBSD.org>
+
+add_executable(
+    lthemeengine
+    main.cpp
+    mainwindow.cpp
+    tabpage.cpp
+    appearancepage.cpp
+    fontspage.cpp
+    lthemeengine.cpp
+    paletteeditdialog.cpp
+    iconthemepage.cpp
+    interfacepage.cpp
+    fontconfigdialog.cpp
+    qsspage.cpp
+    qsseditordialog.cpp
+    cursorthemepage.cpp
+)
+target_link_libraries(lthemeengine PRIVATE libLumina Qt5::Widgets)
+target_compile_definitions(lthemeengine PRIVATE USE_WIDGETS)
+
+install(TARGETS lthemeengine)
+install(FILES lthemeengine.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)


### PR DESCRIPTION
This is a branch, not-finished-yet, that ports the build of `core/` and attendant bits from qmake, to CMake. There is one source-code change. There is also one new build-time dependency: KDE's extra-cmake-modules, which provide all kinds of useful CMake modules for Qt-based applications (and in particular, a FindXCB module).

Filing the PR in draft state so it can be seen to be "in-progress".