### PR TITLE
Fix linkage of lthemeengine-qtplugin

### DIFF
--- a/src-qt5/core/lumina-theme-engine/src/lthemeengine-qtplugin/lthemeengine-qtplugin.pro
+++ b/src-qt5/core/lumina-theme-engine/src/lthemeengine-qtplugin/lthemeengine-qtplugin.pro
@@ -21,6 +21,7 @@ SOURCES += \
 
 OTHER_FILES += lthemeengine.json
 
+LIBS += -lX11
 LIBS += -lXcursor
 QT += x11extras
 


### PR DESCRIPTION
Function XDefineCursor is in libX11